### PR TITLE
Add memory support and quickstart skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "kitaru",
-      "source": ".",
+      "source": "./",
       "description": "Kitaru skills for Claude Code: scoping (flow architecture design) and authoring (writing durable agent workflows)"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
   "description": "Kitaru skills for Claude Code: scoping (flow architecture design) and authoring (writing durable agent workflows)",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a Claude Code plugin, not a Python package. Keep contributor work focused on the plugin metadata and skill documents:
+
+- `skills/kitaru-scoping/SKILL.md` defines the workflow-scoping skill.
+- `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
+- `.claude-plugin/plugin.json` contains plugin metadata such as name, version, and repository URL.
+- `.claude-plugin/marketplace.json` defines the marketplace entry used for local/plugin testing.
+- `README.md` is the public-facing usage and installation guide.
+
+When adding a new skill, follow the existing pattern: `skills/<skill-name>/SKILL.md`.
+
+## Build, Test, and Development Commands
+There is no build step in this repo. Most contributor work is editing Markdown and JSON, then doing a quick manual validation.
+
+- `rg --files` lists the complete tracked file set.
+- `sed -n '1,160p' skills/kitaru-authoring/SKILL.md` previews a skill without opening an editor.
+- `git diff --stat` gives a compact review of changed files.
+- `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
+
+For manual smoke testing, follow the install commands in [`README.md`](README.md) and verify the plugin exposes `/kitaru-scoping` and `/kitaru-authoring`.
+
+## Coding Style & Naming Conventions
+Use Markdown for prose and JSON for plugin metadata. Match the existing style:
+
+- Use concise headings and short paragraphs.
+- Wrap lines at a readable width similar to the current files.
+- Keep examples concrete and technically accurate.
+- Use kebab-case for skill directory names and slash commands, for example `kitaru-scoping`.
+- Preserve valid JSON with two-space indentation in `.claude-plugin/*.json`.
+
+## Testing Guidelines
+There is currently no dedicated automated test suite. Treat testing as documentation validation:
+
+- Check that examples match the current Kitaru API surface.
+- Confirm new trigger phrases and command names are consistent across `SKILL.md`, `README.md`, and plugin metadata.
+- Re-read edited Markdown in rendered form when possible to catch broken lists, code fences, or tables.
+
+## Commit & Pull Request Guidelines
+Recent history uses short, imperative commit messages such as `Update skills for Kitaru memory support` and `Align skills with current Kitaru SDK surface`. Follow that pattern.
+
+Pull requests should explain what changed, why it changed, and which files were updated. If you alter behavior or installation steps, update `README.md` in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Project Structure & Module Organization
 This repository is a Claude Code plugin, not a Python package. Keep contributor work focused on the plugin metadata and skill documents:
 
+- `skills/kitaru-quickstart/SKILL.md` defines the interactive onboarding skill.
 - `skills/kitaru-scoping/SKILL.md` defines the workflow-scoping skill.
 - `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
 - `.claude-plugin/plugin.json` contains plugin metadata such as name, version, and repository URL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+This is a **Claude Code skills plugin** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows. It contains no application code; the deliverables are two Markdown skill files that teach Claude Code how to scope and author Kitaru workflows.
+
+The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-skills`.
+
+## Repository structure
+
+```
+.claude-plugin/
+  plugin.json         # Plugin identity, version, keywords
+  marketplace.json    # Marketplace listing metadata
+skills/
+  kitaru-scoping/SKILL.md    # Structured interview → flow_architecture.md
+  kitaru-authoring/SKILL.md  # Authoring guide for flows, checkpoints, waits, memory, etc.
+```
+
+- **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
+- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
+
+The intended user workflow is: scope first → author second.
+
+## How to work on this repo
+
+There is no build step, no linter, no test suite. The deliverables are the two `SKILL.md` files. Quality comes from:
+
+1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
+2. **Completeness of asymmetry tables** — the skills document capability differences across four surfaces (SDK, KitaruClient, CLI, MCP). These tables must stay synchronized between the two skill files.
+3. **Stable naming** — checkpoint names, wait names, memory scopes, and operator handles are first-class concepts. Changes to naming conventions in the skills ripple into generated architecture documents.
+
+## Key constraints when editing skills
+
+- The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
+- Both skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the other.
+- The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
+- Plugin version is in `.claude-plugin/plugin.json` — bump it when publishing updates.
+
+## Installation methods (for testing)
+
+```bash
+# Marketplace
+/plugin marketplace add zenml-io/kitaru-skills
+/plugin install kitaru@kitaru
+
+# Manual (for local development)
+mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+cp skills/kitaru-scoping/SKILL.md .claude/skills/kitaru-scoping/SKILL.md
+cp skills/kitaru-authoring/SKILL.md .claude/skills/kitaru-authoring/SKILL.md
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,17 @@ The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-sk
   plugin.json         # Plugin identity, version, keywords
   marketplace.json    # Marketplace listing metadata
 skills/
-  kitaru-scoping/SKILL.md    # Structured interview → flow_architecture.md
-  kitaru-authoring/SKILL.md  # Authoring guide for flows, checkpoints, waits, memory, etc.
+  kitaru-quickstart/SKILL.md       # Interactive onboarding → demo flow
+  kitaru-quickstart/references/    # Track templates, host guides, MCP config
+  kitaru-scoping/SKILL.md          # Structured interview → flow_architecture.md
+  kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, memory, etc.
 ```
 
+- **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory, and optional MCP integration.
 - **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
 - **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
 
-The intended user workflow is: scope first → author second.
+The intended user workflow is: quickstart → scope → author.
 
 ## How to work on this repo
 
@@ -35,8 +38,9 @@ There is no build step, no linter, no test suite. The deliverables are the two `
 ## Key constraints when editing skills
 
 - The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
-- Both skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the other.
+- All three skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the others.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
+- The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
 - Plugin version is in `.claude-plugin/plugin.json` — bump it when publishing updates.
 
 ## Installation methods (for testing)
@@ -47,7 +51,8 @@ There is no build step, no linter, no test suite. The deliverables are the two `
 /plugin install kitaru@kitaru
 
 # Manual (for local development)
-mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+mkdir -p .claude/skills/kitaru-quickstart .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+cp -r skills/kitaru-quickstart/ .claude/skills/kitaru-quickstart/
 cp skills/kitaru-scoping/SKILL.md .claude/skills/kitaru-scoping/SKILL.md
 cp skills/kitaru-authoring/SKILL.md .claude/skills/kitaru-authoring/SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ designing and building durable AI agent workflows with
 
 | Skill | Slash command | Purpose |
 |---|---|---|
-| **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, MVP scope) |
-| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, tracked LLM calls, replay/resume/retry, KitaruClient usage, CLI commands, MCP operations, and PydanticAI adapter integrations |
+| **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory-vs-artifact strategy, memory scope design, operator surface, MVP scope) |
+| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient.memories`, replay/resume/retry, CLI memory commands, MCP memory tools, and PydanticAI adapter integrations |
 
 ### Recommended workflow
 
@@ -63,11 +63,14 @@ curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"
 - "Help me figure out where to put checkpoints in my coding agent workflow."
+- "Should repo conventions live in memory or artifacts?"
 - "I have a complex agent with 10 steps — help me scope it down."
 
 **Authoring:**
 - "Refactor this script into one `@flow` with explicit checkpoints."
 - "Add a flow-level `kitaru.wait()` approval gate before publish."
+- "Add `kitaru.memory` durable shared state to this flow."
+- "How do I seed memory from a script and inspect it from the CLI or MCP?"
 - "Wrap this PydanticAI call in a `@checkpoint` and preserve replay safety."
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # Kitaru Skills for Claude Code
 
-Two [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for
-designing and building durable AI agent workflows with
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for
+discovering, designing, and building durable AI agent workflows with
 [Kitaru](https://kitaru.ai).
 
 ## Skills
 
 | Skill | Slash command | Purpose |
 |---|---|---|
+| **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory across executions, and optional MCP integration |
 | **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory-vs-artifact strategy, memory scope design, operator surface, MVP scope) |
 | **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient.memories`, replay/resume/retry, CLI memory commands, MCP memory tools, and PydanticAI adapter integrations |
 
 ### Recommended workflow
 
-1. **Scope first** — use `/kitaru-scoping` to validate fit and define your flow
+1. **Quickstart** — use `/kitaru-quickstart` to see what Kitaru does and
+   build intuition for crash recovery, replay, wait, and memory
+2. **Scope** — use `/kitaru-scoping` to validate fit and define your flow
    architecture before writing code
-2. **Author second** — use `/kitaru-authoring` to build the flows defined in
+3. **Author** — use `/kitaru-authoring` to build the flows defined in
    your `flow_architecture.md`
 
 ## Installation
@@ -59,6 +62,12 @@ curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/
 ```
 
 ## Example prompts
+
+**Quickstart:**
+- "I want to try Kitaru — show me what it does."
+- "Give me a five-minute tour of Kitaru's crash recovery."
+- "Set up a Kitaru demo for my data pipeline workflow."
+- "Walk me through Kitaru with MCP integration."
 
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -1,36 +1,44 @@
 ---
 name: kitaru-authoring
 description: >
-  Guide for writing Kitaru durable workflows and operational control paths. Use
-  when creating or refactoring Kitaru flows, checkpoints, waits, logging,
-  artifacts, tracked LLM calls, replay/resume/retry flows, KitaruClient usage,
-  CLI commands, MCP operations, or PydanticAI adapter integrations. Triggers on
-  mentions of kitaru, @flow, @checkpoint, kitaru.wait, kitaru.log,
-  kitaru.save, kitaru.load, kitaru.llm, KitaruClient, replay, resume, retry,
-  `kitaru run`, `kitaru executions ...`, MCP tools, `wrap(...)`, or
-  `hitl_tool(...)`.
+  Guide for writing Kitaru durable workflows, durable shared memory, and
+  operational control paths. Use when creating or refactoring Kitaru flows,
+  checkpoints, waits, logging, artifacts, `kitaru.memory`,
+  `KitaruClient.memories`, tracked LLM calls, replay/resume/retry flows,
+  KitaruClient usage, CLI commands, MCP operations, or PydanticAI adapter
+  integrations. Triggers on mentions of kitaru, @flow, @checkpoint,
+  kitaru.wait, kitaru.log, kitaru.save, kitaru.load, kitaru.memory,
+  memory.configure, memory.get, memory.set, memory.list, memory.history,
+  memory.delete, KitaruClient, KitaruClient.memories, replay, resume, retry,
+  `kitaru run`, `kitaru executions ...`, `kitaru memory ...`, MCP tools,
+  `kitaru_memory_*`, `wrap(...)`, or `hitl_tool(...)`.
 ---
 
 # Kitaru Authoring Skill
 
 Use this guide when writing or refactoring Kitaru workflows and when choosing
-which Kitaru surface to use for running, observing, replaying, or controlling
-those workflows.
+which Kitaru surface to use for running, observing, replaying, controlling, or
+persisting durable state for those workflows.
 
 > **Before building**: If the workflow shape is still fuzzy, suggest the
 > `kitaru-scoping` skill first. It helps the user decide whether Kitaru is a
-> fit, where checkpoints and waits belong, and which replay anchors should be
-> stable before code gets written.
+> fit, where checkpoints and waits belong, whether memory or artifacts should
+> hold shared state, and which replay anchors should be stable before code gets
+> written.
 
 ## Mental model
 
-Think of a Kitaru flow like a long trip with named save points.
+Think of a Kitaru flow like a long trip with named save points and a shared
+cabinet of durable facts.
 
 - `@flow` is the durable outer boundary.
 - `@checkpoint` is a replay boundary inside that flow.
 - `wait()` pauses at the flow level and resumes later with input.
 - Replay reruns from the top, but checkpoints before the selected replay point
   return cached outputs instead of doing the work again.
+- Artifacts are boxes tied to a specific execution or checkpoint.
+- Memory is the shared cabinet: durable values stored under stable `key + scope`
+  names.
 - Flows are executed with `.run(...)`, not by calling the decorated function
   directly.
 
@@ -68,15 +76,22 @@ Enforce these rules when writing or reviewing Kitaru code:
 2. Do not call one checkpoint from inside another checkpoint.
 3. Do not call `wait()` inside a checkpoint.
 4. `save()` and `load()` require checkpoint scope.
-5. `log()` works in flow scope and checkpoint scope, but it attaches metadata to
+5. `kitaru.memory.*` is allowed in the flow body but forbidden inside a
+   checkpoint.
+6. Outside a flow, call `memory.configure(scope=...)` before using
+   `memory.get()`, `memory.set()`, `memory.list()`, `memory.history()`, or
+   `memory.delete()`.
+7. The module-level `kitaru.memory` API uses the active configured scope; it
+   does not take per-call `scope=` arguments.
+8. `log()` works in flow scope and checkpoint scope, but it attaches metadata to
    different targets depending on where it runs.
-6. Checkpoint outputs must be serializable.
-7. `.submit()`, `.map()`, and `.product()` are for work launched from inside a
-   running flow.
-8. `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
-   synthetic `llm_call` checkpoint automatically.
-9. Use stable, unique names for checkpoints, waits, and artifacts so replay and
-   artifact lookup stay unambiguous.
+9. Checkpoint outputs must be serializable.
+10. `.submit()`, `.map()`, and `.product()` are for work launched from inside a
+    running flow.
+11. `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
+    synthetic `llm_call` checkpoint automatically.
+12. Use stable, unique names for checkpoints, waits, artifacts, memory scopes,
+    and important memory keys so replay and operations stay unambiguous.
 
 ## Primitive reference
 
@@ -134,6 +149,69 @@ inspection or reuse.
 - Allowed artifact kinds are: `prompt`, `response`, `context`, `input`,
   `output`, `blob`
 - Keep artifact names unique within an execution to avoid ambiguous loads
+
+### `memory`
+
+Use `kitaru.memory` for durable shared state addressed by stable keys within one
+active scope.
+
+Public module-level API:
+
+- `memory.configure(scope: str | None = None, *, scope_type: "namespace" | "flow" | "execution" | None = None)`
+- `memory.set(key, value)`
+- `memory.get(key, *, version=None)`
+- `memory.list()`
+- `memory.history(key)`
+- `memory.delete(key)`
+
+Key behavior to teach correctly:
+
+- Valid in the flow body
+- Invalid inside checkpoints
+- Inside a flow, the default scope is the flow name unless you configured a
+  different active scope
+- Outside a flow, you must call `memory.configure(scope=...)` first
+- `memory.configure(scope_type="namespace")` still requires an explicit
+  `scope=...`, while `scope_type="flow"` and `scope_type="execution"` can only
+  be inferred inside a `@flow`
+- The module API uses the active scope; do not invent per-call `scope=` support
+- In flow code, reads like `memory.get()` behave like runtime step outputs, so
+  keep memory calls in the flow body and pass their results into checkpoints
+  when you need normal Python logic
+- Deletes are soft deletes, so `history(...)` includes tombstones
+- Replay is not fully memory-frozen: replays may observe newer values, and
+  replayed writes create new versions
+
+A good pattern is to keep the memory calls in the flow body, then pass the
+result into a checkpoint when you want normal Python logic:
+
+```python
+from kitaru import checkpoint, flow, memory
+
+@checkpoint
+def increment_runs(previous_runs: int | None) -> int:
+    return (previous_runs or 0) + 1
+
+@flow
+def research_agent(topic: str) -> None:
+    previous_runs = memory.get("stats/run_count")
+    updated_runs = increment_runs(previous_runs)
+    memory.set("stats/run_count", updated_runs)
+    memory.set("last_topic", topic)
+```
+
+Outside a flow, configure first:
+
+```python
+from kitaru import memory
+
+memory.configure(scope="repo_docs", scope_type="namespace")
+memory.set("style/release_notes", {"tone": "concise"})
+```
+
+Switch to `KitaruClient.memories` when you need explicit-scope administration,
+prefix filtering, listing scopes, or memory inspection outside the active-scope
+module model.
 
 ### `llm(...)`
 
@@ -199,19 +277,22 @@ in every interface.
 ### SDK (flow objects + helpers)
 
 - Author flows and checkpoints
-- Use `wait`, `log`, `save`, `load`, `llm`
+- Use `wait`, `log`, `save`, `load`, `llm`, `memory.configure`, `memory.set`,
+  `memory.get`, `memory.list`, `memory.history`, `memory.delete`
 - Use `configure(...)`, `connect(server_url, ...)`, `list_stacks()`,
   `current_stack()`, `use_stack()`, `create_stack(...)` (**local stacks only**),
   `delete_stack(...)`
 - Launch executions: `flow.run(...)`, `flow.replay(...)`
 
-### KitaruClient (inspection and control of existing executions)
+### KitaruClient (execution control + explicit memory/artifact inspection)
 
-The client is for **managing existing executions**, not launching new ones.
+The client is for **managing existing executions** and for **explicit-scope
+memory/artifact administration**, not for launching new executions.
 
 - `executions.get / list / latest / logs / pending_waits / input / abort_wait /
   retry / resume / replay / cancel`
 - `artifacts.list / get`
+- `memories.get / list / history / set / delete / scopes`
 
 ### CLI
 
@@ -226,6 +307,10 @@ The client is for **managing existing executions**, not launching new ones.
 - `model register / list`
 - `secrets set / show / list / delete`
 - `executions get / list / logs / input / replay / retry / resume / cancel`
+- `memory scopes / list / get / set / delete / history`
+  - `--scope` is required on all memory commands except `memory scopes`
+  - `memory set` parses JSON when possible; otherwise it stores the raw string
+  - CLI memory does not expose versioned `get` or prefix-filtered `list`
 - JSON output contract: `--output json` / `-o json` emits
   `{command, item}` for single-item commands, `{command, items, count}` for
   lists, and JSONL event objects for `executions logs --follow --output json`
@@ -238,6 +323,8 @@ The client is for **managing existing executions**, not launching new ones.
   `kitaru_executions_replay`, `kitaru_executions_cancel`
 - `get_execution_logs`
 - `kitaru_artifacts_list`, `kitaru_artifacts_get`
+- `kitaru_memory_list`, `kitaru_memory_get`, `kitaru_memory_set`,
+  `kitaru_memory_delete`, `kitaru_memory_history`
 - `kitaru_status`, `kitaru_stacks_list`
 - `manage_stack` (create/delete; supports `local`, `kubernetes`, `vertex`,
   `sagemaker`, `azureml`, plus `extra` and `async_mode`)
@@ -257,6 +344,17 @@ The client is for **managing existing executions**, not launching new ones.
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
 | Switch active stack | Yes | No | Yes | No |
+
+### Memory-specific asymmetries
+
+| Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
+|---|---|---|---|---|
+| Use memory inside flow code | Yes | No | No | No |
+| Outside-flow memory script writes | Yes, after `memory.configure(...)` | Yes | No | No |
+| Explicit-scope admin | Limited (reconfigure active scope) | Yes | Yes | Yes |
+| List memory scopes | No | Yes (`memories.scopes()`) | Yes (`kitaru memory scopes`) | No |
+| Read a specific version | Yes (`memory.get(version=...)`) | Yes | No | Yes |
+| Prefix-filter a list | No | Yes (`memories.list(..., prefix=...)`) | No | Yes |
 
 ## Connection and runtime context
 
@@ -330,16 +428,26 @@ def my_flow(topic: str) -> str:
 
 - Calling `my_flow(...)` directly instead of `my_flow.run(...)`
 - Putting `wait()` inside a checkpoint
+- Calling `memory.*` inside a checkpoint
+- Passing `scope=` to module-level `kitaru.memory` calls even though the module
+  API uses the active configured scope
+- Forgetting `memory.configure(scope=...)` before module-level memory use
+  outside flows
+- Assuming CLI or MCP memory commands infer a default scope
+- Using memory for execution-linked outputs that should be explicit artifacts
+- Assuming memory is replay-deterministic across replays
 - Nesting checkpoint calls
 - Returning non-serializable values from checkpoints
 - Calling `llm()` outside a `@flow`
 - Using vague or duplicate checkpoint / wait names that make replay selectors
   hard to target
 - Reusing artifact names so `load()` becomes ambiguous
+- Reusing unstable memory scope or key names so operators cannot inspect state
+  later
 - Using `wait.*` override keys in replay (they are not supported)
 - Assuming CLI, client, and MCP expose the same operation set
 - Using `KitaruClient` to launch new executions (it's for
-  inspection/control only)
+  inspection/control/memory admin only)
 - Using `connect(...)` and expecting managed workspace support (use
   `kitaru login` for that)
 - Using SDK `create_stack(...)` for remote stacks (it's local-only; use

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -37,8 +37,8 @@ cabinet of durable facts.
 - Replay reruns from the top, but checkpoints before the selected replay point
   return cached outputs instead of doing the work again.
 - Artifacts are boxes tied to a specific execution or checkpoint.
-- Memory is the shared cabinet: durable values stored under stable `key + scope`
-  names.
+- Memory is the shared cabinet: durable values stored under stable
+  `scope_type + scope + key` names.
 - Flows are executed with `.run(...)`, not by calling the decorated function
   directly.
 
@@ -78,11 +78,11 @@ Enforce these rules when writing or reviewing Kitaru code:
 4. `save()` and `load()` require checkpoint scope.
 5. `kitaru.memory.*` is allowed in the flow body but forbidden inside a
    checkpoint.
-6. Outside a flow, call `memory.configure(scope=...)` before using
-   `memory.get()`, `memory.set()`, `memory.list()`, `memory.history()`, or
-   `memory.delete()`.
-7. The module-level `kitaru.memory` API uses the active configured scope; it
-   does not take per-call `scope=` arguments.
+6. Outside a flow, configure an active scope before using `memory.get()`,
+   `memory.set()`, `memory.list()`, `memory.history()`, or `memory.delete()`;
+   `memory.configure(scope=...)` defaults to `scope_type="namespace"`.
+7. The module-level `kitaru.memory` API uses the active configured typed scope;
+   it does not take per-call `scope=` or `scope_type=` arguments.
 8. `log()` works in flow scope and checkpoint scope, but it attaches metadata to
    different targets depending on where it runs.
 9. Checkpoint outputs must be serializable.
@@ -153,7 +153,7 @@ inspection or reuse.
 ### `memory`
 
 Use `kitaru.memory` for durable shared state addressed by stable keys within one
-active scope.
+active configured typed scope (`scope_type` + `scope`).
 
 Public module-level API:
 
@@ -170,15 +170,20 @@ Key behavior to teach correctly:
 - Invalid inside checkpoints
 - Inside a flow, the default scope is the flow name unless you configured a
   different active scope
-- Outside a flow, you must call `memory.configure(scope=...)` first
+- Outside a flow, configure an active scope first; `memory.configure(scope=...)`
+  defaults to `scope_type="namespace"`
 - `memory.configure(scope_type="namespace")` still requires an explicit
   `scope=...`, while `scope_type="flow"` and `scope_type="execution"` can only
   be inferred inside a `@flow`
-- The module API uses the active scope; do not invent per-call `scope=` support
+- The module API uses the active typed scope; do not invent per-call `scope=` or
+  `scope_type=` support
 - In flow code, reads like `memory.get()` behave like runtime step outputs, so
   keep memory calls in the flow body and pass their results into checkpoints
   when you need normal Python logic
 - Deletes are soft deletes, so `history(...)` includes tombstones
+- Maintenance operations are **not** module-level APIs: do not invent
+  `memory.compact()`, `memory.purge()`, `memory.purge_scope()`,
+  `memory.compaction_log()`, or `memory.reindex()`
 - Replay is not fully memory-frozen: replays may observe newer values, and
   replayed writes create new versions
 
@@ -209,9 +214,23 @@ memory.configure(scope="repo_docs", scope_type="namespace")
 memory.set("style/release_notes", {"tone": "concise"})
 ```
 
-Switch to `KitaruClient.memories` when you need explicit-scope administration,
-prefix filtering, listing scopes, or memory inspection outside the active-scope
-module model.
+Switch to `KitaruClient.memories` when you need explicit typed-scope
+administration, prefix filtering, scope listing, maintenance operations, or
+memory inspection outside the active-scope module model.
+
+Maintenance lives on `KitaruClient`, CLI, and MCP surfaces:
+
+- `compact` sends selected memory values to an LLM and writes the summary as a
+  new memory version; it does not delete source entries. Single-key compaction
+  defaults to `source_mode="current"`, can use `source_mode="history"`, and
+  multi-key compaction summarizes current values into a required target key.
+- `purge` / `purge_scope` physically delete old versions; delete is only a
+  tombstone.
+- `compaction_log` reads compact/purge audit records.
+- `reindex` is project-scoped, dry-run by default, additive tag backfill for
+  historical memory discovery; it does not rewrite memory values.
+- `compact` uses an LLM, so make sure a default model or explicit `model=` /
+  `--model` is available.
 
 ### `llm(...)`
 
@@ -286,13 +305,24 @@ in every interface.
 
 ### KitaruClient (execution control + explicit memory/artifact inspection)
 
-The client is for **managing existing executions** and for **explicit-scope
+The client is for **managing existing executions** and for **explicit typed-scope
 memory/artifact administration**, not for launching new executions.
 
 - `executions.get / list / latest / logs / pending_waits / input / abort_wait /
   retry / resume / replay / cancel`
 - `artifacts.list / get`
-- `memories.get / list / history / set / delete / scopes`
+- `memories.get / list(prefix=...) / history / set / delete / scopes / purge /
+  purge_scope / compact / compaction_log / reindex`
+  - Scoped memory calls require explicit `scope=` and `scope_type=`.
+  - `get(..., version=...)` supports versioned reads.
+  - `compact`, `purge`, `purge_scope`, and `compaction_log` are typed-scope
+    maintenance operations.
+  - `reindex(apply=False)` is project-scoped, dry-run by default, and backfills
+    missing memory discovery tags for historical data.
+  - `memories.get(...)`, `list(...)`, and `history(...)` return memory-entry
+    metadata; load values with
+    `client.artifacts.get(entry.artifact_id).load()`. Module-level
+    `memory.get(...)` returns the stored value directly.
 
 ### CLI
 
@@ -307,10 +337,21 @@ memory/artifact administration**, not for launching new executions.
 - `model register / list`
 - `secrets set / show / list / delete`
 - `executions get / list / logs / input / replay / retry / resume / cancel`
-- `memory scopes / list / get / set / delete / history`
-  - `--scope` is required on all memory commands except `memory scopes`
-  - `memory set` parses JSON when possible; otherwise it stores the raw string
-  - CLI memory does not expose versioned `get` or prefix-filtered `list`
+- `memory scopes`; `memory list/get/set/delete/history`; `memory compact`;
+  `memory purge`; `memory purge-scope`; `memory compaction-log`;
+  `memory reindex`
+  - All scoped memory commands require both `--scope` and `--scope-type`.
+  - `memory scopes` and `memory reindex` are unscoped/project-scoped commands.
+  - `memory set` parses JSON when possible; otherwise it stores the raw string.
+  - CLI memory does not expose versioned `get` or prefix-filtered `list`.
+  - `memory compact` summarizes selected memory values with an LLM and writes a
+    new memory version; it may need a configured default model or `--model`.
+  - `memory purge` physically deletes old versions of one key.
+  - `memory purge-scope` physically deletes old versions across a scope;
+    `--include-deleted` also removes tombstoned keys.
+  - `memory compaction-log` reads compact/purge audit records.
+  - `memory reindex` is dry-run by default; use `--apply` to persist missing
+    discovery tags.
 - JSON output contract: `--output json` / `-o json` emits
   `{command, item}` for single-item commands, `{command, items, count}` for
   lists, and JSONL event objects for `executions logs --follow --output json`
@@ -325,6 +366,13 @@ memory/artifact administration**, not for launching new executions.
 - `kitaru_artifacts_list`, `kitaru_artifacts_get`
 - `kitaru_memory_list`, `kitaru_memory_get`, `kitaru_memory_set`,
   `kitaru_memory_delete`, `kitaru_memory_history`
+- `kitaru_memory_compact`, `kitaru_memory_purge`,
+  `kitaru_memory_purge_scope`, `kitaru_memory_compaction_log`
+  - MCP memory tools use explicit typed scopes: every scoped memory tool takes
+    `scope` and `scope_type`.
+  - `kitaru_memory_get` supports `version`; `kitaru_memory_list` supports
+    `prefix`.
+  - MCP does not expose memory scope listing or memory reindexing.
 - `kitaru_status`, `kitaru_stacks_list`
 - `manage_stack` (create/delete; supports `local`, `kubernetes`, `vertex`,
   `sagemaker`, `azureml`, plus `extra` and `async_mode`)
@@ -349,12 +397,18 @@ memory/artifact administration**, not for launching new executions.
 
 | Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
 |---|---|---|---|---|
-| Use memory inside flow code | Yes | No | No | No |
-| Outside-flow memory script writes | Yes, after `memory.configure(...)` | Yes | No | No |
-| Explicit-scope admin | Limited (reconfigure active scope) | Yes | Yes | Yes |
+| In-flow memory reads/writes | Yes | No | No | No |
+| Outside-flow seed/update | Yes, after `memory.configure(...)` | Yes | Yes | Yes |
+| Active-scope Python API | Yes | No | No | No |
+| Explicit typed-scope admin (`scope` + `scope_type`) | No | Yes | Yes | Yes |
 | List memory scopes | No | Yes (`memories.scopes()`) | Yes (`kitaru memory scopes`) | No |
 | Read a specific version | Yes (`memory.get(version=...)`) | Yes | No | Yes |
 | Prefix-filter a list | No | Yes (`memories.list(..., prefix=...)`) | No | Yes |
+| Compact memory | No | Yes | Yes | Yes |
+| Purge one key | No | Yes | Yes | Yes |
+| Purge a whole scope | No | Yes | Yes | Yes |
+| Read compaction/purge audit log | No | Yes | Yes | Yes |
+| Reindex historical memory tags | No | Yes (`reindex(apply=False)`) | Yes (`kitaru memory reindex`) | No |
 
 ## Connection and runtime context
 
@@ -429,11 +483,24 @@ def my_flow(topic: str) -> str:
 - Calling `my_flow(...)` directly instead of `my_flow.run(...)`
 - Putting `wait()` inside a checkpoint
 - Calling `memory.*` inside a checkpoint
-- Passing `scope=` to module-level `kitaru.memory` calls even though the module
-  API uses the active configured scope
-- Forgetting `memory.configure(scope=...)` before module-level memory use
-  outside flows
+- Passing `scope=` or `scope_type=` to module-level `kitaru.memory` calls even
+  though the module API uses the active configured typed scope
+- Forgetting to configure an active scope before module-level memory use outside
+  flows; `memory.configure(scope=...)` defaults to `scope_type="namespace"`
+- Describing memory identity as only a `scope` when the operation requires
+  `scope_type + scope + key`
+- Forgetting `--scope-type` on CLI memory commands
 - Assuming CLI or MCP memory commands infer a default scope
+- Assuming MCP can list memory scopes or run memory reindexing
+- Trying to call maintenance operations on module-level `kitaru.memory`
+- Assuming `compact` deletes source entries; it writes a summary, then `purge`
+  is a separate hard-delete step
+- Treating `delete` and `purge` as interchangeable: delete writes a tombstone;
+  purge physically removes versions
+- Treating `KitaruClient.memories.get(...)` as the raw stored value rather than
+  entry metadata
+- Using invalid memory keys/scopes; use letters, numbers, `.`, `_`, `-`, and
+  `/`, and avoid `:`
 - Using memory for execution-linked outputs that should be explicit artifacts
 - Assuming memory is replay-deterministic across replays
 - Nesting checkpoint calls

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -1,0 +1,502 @@
+---
+name: kitaru-quickstart
+description: >
+  Interactive onboarding for new Kitaru users. Scaffolds a personalized demo
+  flow, demonstrates crash recovery with replay, human-in-the-loop with
+  wait(), durable memory across executions, and optional MCP integration.
+  Use when a user mentions kitaru quickstart, getting started with kitaru,
+  kitaru demo, kitaru onboarding, try kitaru, learn kitaru, what is kitaru,
+  show me kitaru, kitaru tutorial, or wants to see what Kitaru does.
+---
+
+# Kitaru Quickstart
+
+Build and run a working Kitaru demo tailored to the user's domain. Take
+someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
+wait, and memory" in a single session.
+
+> **Relationship to other skills**:
+> - `/kitaru-quickstart` → activation and intuition (this skill)
+> - `/kitaru-scoping` → design durability for a real workflow
+> - `/kitaru-authoring` → refactor production code with Kitaru primitives
+
+## Before you start
+
+Ask three questions using the structured question tool (`AskUserQuestion` in
+Claude Code, `request_user_input` in Codex) before generating any code. If
+no structured question tool exists, ask in chat with short numbered
+questions.
+
+### Question 1: Domain
+
+> Which workflow is closest to what you care about?
+
+- **Research/content** — gather → draft → approve → publish
+- **Coding agent** — analyze issue → generate patch → approve → merge
+- **Data pipeline** — ingest → validate → transform → load
+- **Support/triage** — classify → draft response → approve → escalate
+- **Other**
+
+If the user picks "other" and their use case does not map to any track,
+suggest they describe their architecture in the
+[ZenML Slack](https://zenml.io/slack) or open an issue on
+[zenml-io/kitaru](https://github.com/zenml-io/kitaru) so it can be scoped
+properly. Then default to the research/content track for the demo.
+
+### Question 2: Runtime
+
+> Which runtime should the demo use?
+
+- **Raw Python** (default) — no dependencies beyond Kitaru, uses mock
+  functions with `time.sleep()`
+- **PydanticAI** — uses `TestModel`, no API keys needed
+- **Simplest working path** — you choose
+
+For v1, use the raw Python track template regardless of choice. If the user
+specifically requests PydanticAI, complete the quickstart in raw Python and
+then offer `/kitaru-authoring` for PydanticAI conversion.
+
+### Question 3: Depth
+
+> How deep today?
+
+- **Five-minute tour** — crash → replay demo only
+- **Guided build** — full walkthrough
+- **Guided build + MCP** — full walkthrough with MCP integration
+
+## Depth routing
+
+| Depth              | Phases              |
+|--------------------|---------------------|
+| Five-minute tour   | 0 → 1 → 5          |
+| Guided build       | 0 → 1 → 2 → 2.5 → 3 → 5 |
+| Guided build + MCP | 0 → 1 → 2 → 2.5 → 3 → 4 → 5 |
+
+---
+
+## Phase 0: Environment setup
+
+1. **Check safety**: Is the current directory safe to modify?
+   - If it has `src/`, `.git` with uncommitted changes, `package.json`,
+     `pyproject.toml`, or other project markers: ask the user and default to
+     creating `./kitaru-quickstart-demo/`.
+   - If it is empty or a scratch directory: work here.
+
+2. **Verify Python**: `python3 --version` (require 3.10+)
+
+3. **Verify uv**: `uv --version`
+   - If missing, suggest:
+     `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+4. **Create project and install Kitaru**:
+   ```bash
+   mkdir -p kitaru-quickstart-demo
+   cd kitaru-quickstart-demo
+   uv init --no-workspace
+   uv add kitaru
+   ```
+
+5. **Initialize Kitaru**: `kitaru init`
+
+6. **Verify**: `kitaru status`
+
+If any step fails, explain the error, apply a fix, and retry once. If it
+fails again, present the error to the user and ask for guidance.
+
+---
+
+## Phase 1: Crash-and-replay demo
+
+This is the core activation sequence. It must feel dramatic, not academic.
+
+### Step 1: Load the track template
+
+Read the template from `references/tracks/{track}.py` based on the user's
+domain choice:
+
+| Domain          | Template file  | Flow name        |
+|-----------------|---------------|------------------|
+| Research/content| `research.py` | `research_flow`  |
+| Coding agent    | `coding.py`   | `coding_flow`    |
+| Data pipeline   | `data.py`     | `data_flow`      |
+| Support/triage  | `support.py`  | `support_flow`   |
+
+### Step 2: Customize the template
+
+Adapt variable names, mock data, and print statements to the user's domain.
+
+**CRITICAL**: Do NOT alter the placement, arguments, or syntax of `@flow`,
+`@checkpoint`, `wait()`, `log()`, or `memory.*` calls. Only customize the
+internal business logic of checkpoint functions (string content, mock data
+values, variable names).
+
+### Step 3: Write the customized flow
+
+Write the customized template to `demo_flow.py` in the project directory.
+The template includes a pre-baked crash marked with:
+
+```python
+# --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+raise Exception("Simulated ...")
+# --- end crash ---
+```
+
+### Step 4: Run the flow (it will crash)
+
+```bash
+uv run python demo_flow.py
+```
+
+Read the output. Verify you see a traceback at the second checkpoint.
+
+### Step 5: Explain the crash
+
+Tell the user:
+
+> "The flow crashed at the second checkpoint. In a traditional script,
+> everything from checkpoint 1 would be lost — you'd rerun the entire
+> pipeline and redo all that work. With Kitaru, checkpoint 1's output is
+> saved to the local SQLite database. Let's fix the crash and replay from
+> exactly where it broke."
+
+### Step 6: Fix the code
+
+Remove the lines between `# --- QUICKSTART CRASH ---` and
+`# --- end crash ---` from `demo_flow.py`.
+
+### Step 7: Get the execution ID
+
+From the crash output, or run:
+
+```bash
+kitaru executions list --output json
+```
+
+Extract the execution ID of the failed run.
+
+### Step 8: Replay from the failed checkpoint
+
+```bash
+kitaru executions replay <EXEC_ID> --from <CHECKPOINT_NAME>
+```
+
+Checkpoint names by track:
+
+| Track           | Replay from       |
+|-----------------|-------------------|
+| Research/content| `draft_content`   |
+| Coding agent    | `generate_patch`  |
+| Data pipeline   | `transform`       |
+| Support/triage  | `draft_response`  |
+
+### Step 9: Verify and explain
+
+Read the replay output. Verify that checkpoint 1 was loaded from cache (not
+re-executed). Then tell the user:
+
+> "Notice that the first checkpoint was loaded from cache and skipped —
+> only the second checkpoint onwards re-executed. That's crash recovery
+> with zero wasted work. In production, this means no burned tokens, no
+> repeated API calls, no lost progress."
+
+**Verification**: If the output does not show caching behavior, read the
+full output, diagnose the issue, and retry once.
+
+If the user chose **five-minute tour**, skip to **Phase 5**.
+
+---
+
+## Phase 2: Human-in-the-loop with `wait()`
+
+### Step 1: Run the flow again
+
+The crash is now fixed. Run the flow:
+
+```bash
+uv run python demo_flow.py
+```
+
+The flow will pause at the `wait()` gate.
+
+### Step 2: Explain the pause
+
+> "The flow is now paused at a wait gate. In production, your agent
+> releases compute while waiting — no idle containers burning money. The
+> execution state is safely persisted. A human (or another agent) can
+> provide input whenever they're ready."
+
+### Step 3: Provide input
+
+```bash
+kitaru executions input <EXEC_ID> --wait <WAIT_NAME> --value true
+```
+
+Wait names by track:
+
+| Track           | Wait name            |
+|-----------------|----------------------|
+| Research/content| `approve_draft`      |
+| Coding agent    | `approve_merge`      |
+| Data pipeline   | `approve_load`       |
+| Support/triage  | `approve_escalation` |
+
+### Step 4: Resume if needed
+
+If the execution does not auto-continue:
+
+```bash
+kitaru executions resume <EXEC_ID>
+```
+
+### Step 5: Verify completion
+
+Confirm the flow completed successfully and show the final output.
+
+---
+
+## Phase 2.5: Durable memory demo
+
+### Step 1: Explain memory
+
+> "Kitaru has durable memory — your flows can remember state across
+> executions. The flow you just ran stored some context. Let's run it
+> again with different input and watch it remember."
+
+### Step 2: Run the flow again with different input
+
+Choose a different argument that makes sense for the track:
+
+| Track           | Example second input             |
+|-----------------|----------------------------------|
+| Research/content| `"quantum computing"`            |
+| Coding agent    | `"optimize database query speed"`|
+| Data pipeline   | `"inventory_data_2026_q2.csv"`   |
+| Support/triage  | `"login page returns 500 error"` |
+
+```bash
+uv run python demo_flow.py "<new input>"
+```
+
+### Step 3: Point out the memory detection
+
+The flow logs should show it detected the previous input from memory. Point
+this out to the user.
+
+### Step 4: Inspect memory from the CLI
+
+```bash
+kitaru memory list --scope <FLOW_NAME>
+kitaru memory get last_topic --scope <FLOW_NAME>
+```
+
+Memory key names by track:
+
+| Track           | Flow name       | Memory key     |
+|-----------------|-----------------|----------------|
+| Research/content| `research_flow` | `last_topic`   |
+| Coding agent    | `coding_flow`   | `last_issue`   |
+| Data pipeline   | `data_flow`     | `last_source`  |
+| Support/triage  | `support_flow`  | `last_ticket`  |
+
+### Step 5: Explain
+
+> "Memory persists across executions under stable keys. Your agent can
+> accumulate knowledge, preferences, or context over time. Operators can
+> inspect or edit that state from the CLI, Python client, or MCP tools."
+
+---
+
+## Phase 3: Inspect and explore
+
+### Step 1: Show execution history
+
+```bash
+kitaru executions list
+```
+
+### Step 2: Inspect a specific execution
+
+```bash
+kitaru executions get <EXEC_ID>
+```
+
+### Step 3: View structured logs
+
+```bash
+kitaru executions logs <EXEC_ID>
+```
+
+### Step 4: Explain
+
+> "Every checkpoint, wait, memory operation, and log call is tracked.
+> This gives you full observability into what your agent did, when, and
+> why — without building custom logging infrastructure."
+
+---
+
+## Phase 4: MCP integration (opt-in)
+
+Only run this phase if the user chose **guided build + MCP**.
+
+### Step 1: Explain the value
+
+> "I can configure your environment so I can directly query Kitaru's
+> execution database, provide input to waiting flows, and trigger
+> replays — all through natural language."
+
+### Step 2: Detect the host
+
+Check filesystem markers:
+
+- `.claude/` → Claude Code
+- `.cursor/` or `.cursorignore` → Cursor
+- `.codex/` → Codex CLI
+
+If no markers found or multiple matches, ask the user which host they are
+using.
+
+### Step 3: Install the MCP extra
+
+```bash
+uv add kitaru --extra mcp
+```
+
+### Step 4: Load the host-specific guide
+
+Read the appropriate file from `references/hosts/{host}.md`:
+
+- Claude Code → `references/hosts/claude-code.md`
+- Cursor → `references/hosts/cursor.md`
+- Codex → `references/hosts/codex.md`
+- Copilot → `references/hosts/copilot.md`
+- Gemini → `references/hosts/gemini.md`
+
+### Step 5: Ask for explicit consent
+
+Before modifying any configuration file:
+
+1. Show the exact file path that will be created or modified.
+2. Show the exact content or diff that will be written.
+3. Ask for explicit approval.
+
+**Never write to MCP config files without consent.**
+
+### Step 6: Apply configuration
+
+Follow the host-specific guide to configure the MCP server.
+
+### Step 7: Demonstrate MCP tools
+
+Show at least 3 MCP tools in action against the demo flow:
+
+1. **List executions** — show the executions from earlier phases
+2. **Inspect execution** — read status and details of a specific run
+3. **Read logs** — show structured logs from a checkpoint
+
+If a wait is currently pending, also demonstrate:
+4. **Provide input** — resolve a wait via MCP
+
+If applicable:
+5. **Replay** — trigger a replay via MCP
+
+### Step 8: Handle failure
+
+If MCP installation or configuration fails:
+
+1. Read `references/mcp-config-guide.md`
+2. Explain the manual setup path to the user
+3. Continue to Phase 5 without MCP
+
+---
+
+## Phase 5: Handoff and next steps
+
+### Step 1: Write `KITARU_NEXT_STEPS.md`
+
+Write this file to the project directory, filling in the actual values from
+the session:
+
+```markdown
+# Kitaru Quickstart — What You Built
+
+## Demo summary
+- **Domain**: [user's chosen domain]
+- **Flow**: [flow name] with [N] checkpoints
+- **Demonstrated**: crash recovery, replay[, wait(), memory, MCP]
+
+## Kitaru primitives used
+
+| Primitive | What it does | Where you saw it |
+|---|---|---|
+| `@flow` | Durable orchestration boundary | `demo_flow.py` |
+| `@checkpoint` | Replay-safe unit of work | `demo_flow.py` |
+| `wait()` | Human-in-the-loop gate | `demo_flow.py` |
+| `log()` | Structured metadata | `demo_flow.py` |
+| `memory.set/get` | Cross-execution durable state | `demo_flow.py` |
+| `replay` | Re-execute from a checkpoint | CLI |
+
+## Next steps
+- **`/kitaru-scoping`** — Design durability for a real workflow
+- **`/kitaru-authoring`** — Refactor existing code with Kitaru primitives
+
+## Resources
+- [Kitaru documentation](https://kitaru.ai/docs)
+- [ZenML Slack](https://zenml.io/slack)
+- [Kitaru SDK repository](https://github.com/zenml-io/kitaru)
+```
+
+Adjust the "Demonstrated" line and primitives table based on which phases
+actually ran (five-minute tour only shows crash recovery and replay).
+
+### Step 2: Offer next steps
+
+> "Your quickstart is complete! Here's what you can do next:"
+>
+> - **`/kitaru-scoping`** if you want to design durability for a real
+>   workflow
+> - **`/kitaru-authoring`** if you have existing code you'd like to
+>   refactor with Kitaru primitives
+
+---
+
+## Guardrails
+
+Enforce these rules throughout the entire session:
+
+1. **Template integrity**: Never alter the placement, arguments, or syntax
+   of `@flow`, `@checkpoint`, `wait()`, `log()`, `memory.*`, `save()`, or
+   `load()` decorators or calls. Only customize the internal business
+   logic of checkpoint functions.
+
+2. **Scope limit**: Keep generated code under 150 lines. Use mock functions
+   with `time.sleep()` to simulate latency. Do not implement real API
+   connections or complex data processing.
+
+3. **Verification**: After every terminal command, read the output and
+   verify success before proceeding. Never assume a command worked.
+
+4. **Failure recovery**: If a step fails, explain the error, apply a fix,
+   and retry once. If it fails again, present the error to the user and
+   ask for guidance. Do not loop.
+
+5. **MCP consent**: Never write to MCP config files without showing the
+   user the exact diff and receiving explicit approval.
+
+6. **No blanket shell approval**: Do not request broad shell preapproval
+   from the user.
+
+7. **Memory placement**: `memory.*` calls belong in the flow body only,
+   never inside checkpoints.
+
+8. **Real commands only**: Use only documented Kitaru CLI commands:
+   - Replay: `kitaru executions replay <id> --from <checkpoint>`
+     (not `kitaru replay`)
+   - There is no `kitaru ui` command
+   - There is no top-level `kitaru run` command
+   - Wait input: `kitaru executions input <id> --wait <name> --value <val>`
+
+9. **No API key requirements**: The quickstart must run without any API
+   keys, cloud credentials, or external service accounts.
+
+10. **Checkpoint outputs must be serializable**: All mock return values from
+    checkpoints must be JSON-serializable (strings, numbers, lists, dicts).

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -284,19 +284,23 @@ this out to the user.
 
 ### Step 4: Inspect memory from the CLI
 
+The templates use module-level `kitaru.memory` inside the flow body, so the
+values live in the default flow typed scope. CLI inspection needs both the
+scope value and the scope type:
+
 ```bash
-kitaru memory list --scope <FLOW_NAME>
-kitaru memory get last_topic --scope <FLOW_NAME>
+kitaru memory list --scope <FLOW_NAME> --scope-type flow
+kitaru memory get <MEMORY_KEY> --scope <FLOW_NAME> --scope-type flow
 ```
 
-Memory key names by track:
+Memory scope and key names by track:
 
-| Track           | Flow name       | Memory key     |
-|-----------------|-----------------|----------------|
-| Research/content| `research_flow` | `last_topic`   |
-| Coding agent    | `coding_flow`   | `last_issue`   |
-| Data pipeline   | `data_flow`     | `last_source`  |
-| Support/triage  | `support_flow`  | `last_ticket`  |
+| Track            | Scope type | Scope value     | Memory key    |
+|------------------|------------|-----------------|---------------|
+| Research/content | `flow`     | `research_flow` | `last_topic`  |
+| Coding agent     | `flow`     | `coding_flow`   | `last_issue`  |
+| Data pipeline    | `flow`     | `data_flow`     | `last_source` |
+| Support/triage   | `flow`     | `support_flow`  | `last_ticket` |
 
 ### Step 5: Explain
 

--- a/skills/kitaru-quickstart/references/hosts/claude-code.md
+++ b/skills/kitaru-quickstart/references/hosts/claude-code.md
@@ -1,0 +1,46 @@
+# Claude Code — MCP Setup
+
+## Detection markers
+
+- `.claude/` directory exists
+- `.claude/settings.json` exists
+
+## Option A: CLI registration (recommended)
+
+```bash
+claude mcp add kitaru kitaru-mcp
+```
+
+This registers the Kitaru MCP server in Claude Code's project-scoped
+configuration. No file edits needed.
+
+## Option B: Project `.mcp.json` file
+
+Create or merge into `.mcp.json` at the project root:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+If `.mcp.json` already exists, merge the `kitaru` key into the existing
+`mcpServers` object. Do not overwrite other servers.
+
+## After setup
+
+Claude Code picks up MCP changes on the next message. No restart is needed.
+
+## Scopes
+
+Claude Code supports three configuration scopes:
+
+- **Project** (`.mcp.json` in project root) — recommended for quickstart
+- **User** (`~/.claude/settings.json`)
+- **Organization** (managed by team admin)
+
+The CLI `claude mcp add` command defaults to project scope.

--- a/skills/kitaru-quickstart/references/hosts/codex.md
+++ b/skills/kitaru-quickstart/references/hosts/codex.md
@@ -1,0 +1,34 @@
+# Codex CLI — MCP Setup
+
+## Detection markers
+
+- `.codex/` directory exists
+
+## Configuration
+
+Codex CLI MCP configuration is not yet authoritatively documented in the
+Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult the Codex CLI documentation for the correct MCP
+configuration path and format, then use `kitaru-mcp` as the server command.
+
+If the user knows their Codex MCP config location, the general pattern is:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/hosts/copilot.md
+++ b/skills/kitaru-quickstart/references/hosts/copilot.md
@@ -1,0 +1,23 @@
+# GitHub Copilot — MCP Setup
+
+## Detection markers
+
+No reliable filesystem markers for Copilot. Ask the user to confirm their
+host if Copilot is suspected.
+
+## Configuration
+
+GitHub Copilot MCP configuration is not yet authoritatively documented in
+the Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult GitHub Copilot documentation for MCP server
+registration, then use `kitaru-mcp` as the server command.
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/hosts/cursor.md
+++ b/skills/kitaru-quickstart/references/hosts/cursor.md
@@ -1,0 +1,31 @@
+# Cursor — MCP Setup
+
+## Detection markers
+
+- `.cursor/` directory exists
+- `.cursorignore` file exists
+- `.cursorindexingignore` file exists
+
+## Configuration
+
+Create or merge into `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp",
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+If `.cursor/mcp.json` already exists, merge the `kitaru` key into the
+existing `mcpServers` object. Do not overwrite other servers.
+
+## After setup
+
+Cursor may need a reload to pick up MCP configuration changes. Suggest the
+user reload the window or restart Cursor if tools are not immediately
+available.

--- a/skills/kitaru-quickstart/references/hosts/gemini.md
+++ b/skills/kitaru-quickstart/references/hosts/gemini.md
@@ -1,0 +1,23 @@
+# Gemini CLI — MCP Setup
+
+## Detection markers
+
+No reliable filesystem markers for Gemini CLI. Ask the user to confirm
+their host if Gemini is suspected.
+
+## Configuration
+
+Gemini CLI MCP configuration is not yet authoritatively documented in the
+Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult Gemini CLI documentation for MCP server
+registration, then use `kitaru-mcp` as the server command.
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -74,16 +74,25 @@ Once configured, the Kitaru MCP server exposes these tools:
 - `kitaru_executions_replay` — replay from a checkpoint
 - `kitaru_executions_cancel` — cancel a running execution
 - `get_execution_logs` — read execution logs
-- `kitaru_memory_list` — list memory entries in a scope
-- `kitaru_memory_get` — read a memory value
+- `kitaru_memory_list` — list memory entries in a known typed scope
+- `kitaru_memory_get` — read a memory value from a known typed scope
 - `kitaru_memory_set` — write a memory value
-- `kitaru_memory_delete` — delete a memory key
+- `kitaru_memory_delete` — soft-delete a memory key
 - `kitaru_memory_history` — view version history for a key
+- `kitaru_memory_compact` — summarize memory values with an LLM
+- `kitaru_memory_purge` — physically delete old versions of one key
+- `kitaru_memory_purge_scope` — physically delete old versions across a scope
+- `kitaru_memory_compaction_log` — inspect compact/purge audit records
 - `kitaru_artifacts_list` — list artifacts for an execution
 - `kitaru_artifacts_get` — read an artifact
 - `kitaru_status` — check Kitaru connection status
 - `kitaru_stacks_list` — list available stacks
 - `manage_stack` — create or delete stacks
+
+Memory tools operate on explicit typed scopes: provide both `scope` and
+`scope_type` for scoped memory calls. `kitaru_memory_get` supports `version`,
+and `kitaru_memory_list` supports `prefix`. MCP can work with a known memory
+scope, but it does not currently expose memory scope listing or memory reindexing.
 
 ## Authentication
 

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -1,0 +1,94 @@
+# Kitaru MCP Server — Manual Setup Guide
+
+Use this guide when automatic host detection fails or when the user's host
+is not directly supported.
+
+## Install the MCP extra
+
+```bash
+uv add kitaru --extra mcp
+```
+
+Or with pip:
+
+```bash
+pip install "kitaru[mcp]"
+```
+
+## Verify installation
+
+```bash
+kitaru-mcp --help
+```
+
+If `kitaru-mcp` is not found, ensure the Python environment where Kitaru is
+installed is activated.
+
+## Server executable
+
+The MCP server command is:
+
+```
+kitaru-mcp
+```
+
+It uses stdio transport by default.
+
+## Generic MCP configuration
+
+Most hosts use a JSON configuration file with this schema:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+Some hosts require an explicit transport field:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp",
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+## Available MCP tools
+
+Once configured, the Kitaru MCP server exposes these tools:
+
+- `kitaru_executions_list` — list recent executions
+- `kitaru_executions_get` — inspect an execution
+- `kitaru_executions_latest` — get the most recent execution
+- `kitaru_executions_run` — run a flow
+- `kitaru_executions_input` — provide input to a waiting execution
+- `kitaru_executions_retry` — retry a failed execution
+- `kitaru_executions_replay` — replay from a checkpoint
+- `kitaru_executions_cancel` — cancel a running execution
+- `get_execution_logs` — read execution logs
+- `kitaru_memory_list` — list memory entries in a scope
+- `kitaru_memory_get` — read a memory value
+- `kitaru_memory_set` — write a memory value
+- `kitaru_memory_delete` — delete a memory key
+- `kitaru_memory_history` — view version history for a key
+- `kitaru_artifacts_list` — list artifacts for an execution
+- `kitaru_artifacts_get` — read an artifact
+- `kitaru_status` — check Kitaru connection status
+- `kitaru_stacks_list` — list available stacks
+- `manage_stack` — create or delete stacks
+
+## Authentication
+
+The MCP server uses the same authentication context as the Kitaru CLI. If
+you are logged in via `kitaru login`, the MCP server will use those
+credentials.
+
+For local-only usage (no remote server), no login is needed.

--- a/skills/kitaru-quickstart/references/tracks/coding.py
+++ b/skills/kitaru-quickstart/references/tracks/coding.py
@@ -1,0 +1,85 @@
+"""Coding agent flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: analyze issue → generate patch → approve → apply patch
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def analyze_issue(issue: str) -> dict:
+    """Simulate analyzing a code issue."""
+    log(step="analyze", issue=issue)
+    time.sleep(1)
+    return {
+        "issue": issue,
+        "files": ["src/main.py", "src/utils.py"],
+        "severity": "medium",
+        "root_cause": f"Incorrect handling of edge case in {issue}",
+    }
+
+
+@checkpoint
+def generate_patch(analysis: dict) -> str:
+    """Simulate generating a code patch."""
+    log(step="generate_patch", files=analysis["files"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated timeout calling code generation model")
+    # --- end crash ---
+    time.sleep(2)
+    patch = (
+        f"--- a/src/main.py\n"
+        f"+++ b/src/main.py\n"
+        f"@@ -42,3 +42,5 @@\n"
+        f"-    return process(data)\n"
+        f"+    if not data:\n"
+        f'+        raise ValueError("Empty input")\n'
+        f"+    return process(data)\n"
+    )
+    return patch
+
+
+@checkpoint
+def apply_patch(patch: str) -> str:
+    """Simulate applying the approved patch."""
+    log(step="apply", patch_length=len(patch))
+    time.sleep(1)
+    return f"Patch applied successfully ({len(patch)} chars)"
+
+
+@flow
+def coding_flow(issue: str) -> str:
+    """Analyze an issue, generate a patch, review, and apply it."""
+    previous_issue = memory.get("last_issue")
+    if previous_issue:
+        log(returning_user=True, previous_issue=previous_issue)
+
+    analysis = analyze_issue(issue)
+    patch = generate_patch(analysis)
+
+    approved = wait(
+        name="approve_merge",
+        question=f"Approve patch for '{issue}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Patch for '{issue}' was rejected"
+
+    result = apply_patch(patch)
+    memory.set("last_issue", issue)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    issue = sys.argv[1] if len(sys.argv) > 1 else "fix null pointer in data processor"
+    handle = coding_flow.run(issue)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/data.py
+++ b/skills/kitaru-quickstart/references/tracks/data.py
@@ -1,0 +1,102 @@
+"""Data pipeline flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: ingest → validate → transform → approve → load
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def ingest(source: str) -> list[dict]:
+    """Simulate ingesting raw data from a source."""
+    log(step="ingest", source=source)
+    time.sleep(1)
+    return [
+        {"id": 1, "value": 100, "status": "active"},
+        {"id": 2, "value": -5, "status": "active"},
+        {"id": 3, "value": 200, "status": "inactive"},
+    ]
+
+
+@checkpoint
+def validate(records: list[dict]) -> dict:
+    """Simulate validating ingested records."""
+    log(step="validate", record_count=len(records))
+    time.sleep(1)
+    issues = [r for r in records if r["value"] < 0]
+    return {
+        "valid_count": len(records) - len(issues),
+        "issue_count": len(issues),
+        "issues": issues,
+        "records": records,
+    }
+
+
+@checkpoint
+def transform(validation: dict) -> list[dict]:
+    """Simulate transforming validated data."""
+    log(step="transform", valid_count=validation["valid_count"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated schema mismatch during transformation")
+    # --- end crash ---
+    time.sleep(2)
+    transformed = []
+    for r in validation["records"]:
+        if r["value"] >= 0:
+            transformed.append({
+                "id": r["id"],
+                "value_normalized": r["value"] / 100.0,
+                "is_active": r["status"] == "active",
+            })
+    return transformed
+
+
+@checkpoint
+def load_data(records: list[dict]) -> str:
+    """Simulate loading transformed data into a destination."""
+    log(step="load", record_count=len(records))
+    time.sleep(1)
+    return f"Loaded {len(records)} records into warehouse"
+
+
+@flow
+def data_flow(source: str) -> str:
+    """Ingest, validate, transform, approve, and load data."""
+    previous_source = memory.get("last_source")
+    if previous_source:
+        log(returning_user=True, previous_source=previous_source)
+
+    raw = ingest(source)
+    validation = validate(raw)
+
+    if validation["issue_count"] > 0:
+        log(data_quality_warning=True, issues=validation["issues"])
+
+    transformed = transform(validation)
+
+    approved = wait(
+        name="approve_load",
+        question=f"Approve loading {len(transformed)} records? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return "Data load was rejected"
+
+    result = load_data(transformed)
+    memory.set("last_source", source)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    source = sys.argv[1] if len(sys.argv) > 1 else "sales_data_2026_q1.csv"
+    handle = data_flow.run(source)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/research.py
+++ b/skills/kitaru-quickstart/references/tracks/research.py
@@ -1,0 +1,77 @@
+"""Research/content approval flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: gather sources → draft content → approve → publish
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def gather_sources(topic: str) -> list[str]:
+    """Simulate gathering research sources."""
+    log(step="gather", topic=topic)
+    time.sleep(1)
+    return [
+        f"Academic paper on {topic}",
+        f"Industry report: {topic} trends 2026",
+        f"Expert interview transcript about {topic}",
+    ]
+
+
+@checkpoint
+def draft_content(topic: str, sources: list[str]) -> str:
+    """Draft content from gathered sources."""
+    log(step="draft", source_count=len(sources))
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated network timeout during content generation")
+    # --- end crash ---
+    time.sleep(2)
+    lines = [f"# {topic}", "", "## Key Findings", ""]
+    lines.extend(f"- Finding from: {s}" for s in sources)
+    return "\n".join(lines)
+
+
+@checkpoint
+def publish(draft: str) -> str:
+    """Simulate publishing the approved content."""
+    log(step="publish", draft_length=len(draft))
+    time.sleep(1)
+    return f"Published at https://example.com/articles/{abs(hash(draft)) % 10000}"
+
+
+@flow
+def research_flow(topic: str) -> str:
+    """Research, draft, approve, and publish content about a topic."""
+    previous_topic = memory.get("last_topic")
+    if previous_topic:
+        log(returning_user=True, previous_topic=previous_topic)
+
+    sources = gather_sources(topic)
+    draft = draft_content(topic, sources)
+
+    approved = wait(
+        name="approve_draft",
+        question=f"Approve draft about '{topic}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Draft about '{topic}' was rejected"
+
+    result = publish(draft)
+    memory.set("last_topic", topic)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    topic = sys.argv[1] if len(sys.argv) > 1 else "durable AI agents"
+    handle = research_flow.run(topic)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/support.py
+++ b/skills/kitaru-quickstart/references/tracks/support.py
@@ -1,0 +1,82 @@
+"""Support/triage flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: classify ticket → draft response → approve → escalate
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def classify_ticket(ticket: str) -> dict:
+    """Simulate classifying an incoming support ticket."""
+    log(step="classify", ticket=ticket)
+    time.sleep(1)
+    return {
+        "ticket": ticket,
+        "category": "billing",
+        "priority": "high",
+        "sentiment": "frustrated",
+    }
+
+
+@checkpoint
+def draft_response(classification: dict) -> str:
+    """Simulate drafting a response to the classified ticket."""
+    log(step="draft_response", category=classification["category"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated timeout calling response generation model")
+    # --- end crash ---
+    time.sleep(2)
+    return (
+        f"Dear customer,\n\n"
+        f"Thank you for reaching out about your {classification['category']} issue. "
+        f"We understand this is urgent (priority: {classification['priority']}). "
+        f"We're looking into this and will follow up within 24 hours.\n\n"
+        f"Best regards,\nSupport Team"
+    )
+
+
+@checkpoint
+def escalate(ticket: str, response: str) -> str:
+    """Simulate escalating the ticket with the approved response."""
+    log(step="escalate", ticket=ticket, response_length=len(response))
+    time.sleep(1)
+    return f"Ticket escalated to senior support. Response sent ({len(response)} chars)"
+
+
+@flow
+def support_flow(ticket: str) -> str:
+    """Classify a ticket, draft a response, approve, and escalate."""
+    previous_ticket = memory.get("last_ticket")
+    if previous_ticket:
+        log(returning_user=True, previous_ticket=previous_ticket)
+
+    classification = classify_ticket(ticket)
+    response = draft_response(classification)
+
+    approved = wait(
+        name="approve_escalation",
+        question=f"Approve escalation for '{ticket}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Escalation for '{ticket}' was rejected"
+
+    result = escalate(ticket, response)
+    memory.set("last_ticket", ticket)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    ticket = sys.argv[1] if len(sys.argv) > 1 else "billing charge incorrect on invoice #1234"
+    handle = support_flow.run(ticket)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -3,17 +3,19 @@ name: kitaru-scoping
 description: >-
   Scope and validate whether an agent workflow is well-suited for Kitaru's
   durable execution model, then design the flow architecture — checkpoint
-  boundaries, wait points, replay anchors, artifact strategy, operator surface,
-  and MVP scope. Runs a structured interview to help users identify what
-  benefits from durability, what doesn't, and where replay/resume boundaries
-  should go. Produces a flow_architecture.md specification document. Use this
-  skill whenever a user describes an agent workflow they want to make durable,
-  asks whether Kitaru is right for their use case, seems unsure about where to
-  place checkpoints or waits, needs to choose between SDK / KitaruClient / CLI
-  / MCP control surfaces, or arrives with a workflow that might be too simple
-  or too complex for Kitaru. Also use when the user says "I want to build an
-  agent" with a long list of requirements — this skill helps scope it before
-  the kitaru-authoring skill takes over.
+  boundaries, wait points, replay anchors, memory-vs-artifact strategy,
+  memory scope design, operator surface, and MVP scope. Runs a structured
+  interview to help users identify what benefits from durability, what doesn't,
+  what should live in memory versus artifacts, and where replay/resume
+  boundaries should go. Produces a flow_architecture.md specification document.
+  Use this skill whenever a user describes an agent workflow they want to make
+  durable, asks whether Kitaru is right for their use case, seems unsure about
+  where to place checkpoints or waits, needs to choose between SDK /
+  KitaruClient / CLI / MCP control surfaces, asks how to handle cross-execution
+  shared state, or arrives with a workflow that might be too simple or too
+  complex for Kitaru. Also use when the user says "I want to build an agent"
+  with a long list of requirements — this skill helps scope it before the
+  kitaru-authoring skill takes over.
 ---
 
 # Scope Kitaru Flow Architectures
@@ -27,14 +29,15 @@ flow architecture that the authoring skill can implement cleanly.
 Users often arrive in one of these states:
 
 - **The everything-flow**: one giant workflow that tries to mix planning,
-  execution, approvals, retries, side effects, and reporting into a single
-  tangled structure.
+  execution, approvals, retries, side effects, durable state, and reporting
+  into a single tangled structure.
 - **The over-checkpointed design**: every tiny helper is a checkpoint, which
   adds serialization cost without adding replay value.
 - **The wrong tool problem**: the user needs streaming chat, sub-100ms serving,
   or a plain script rather than durable orchestration.
 - **The fuzzy durability problem**: the workflow might be a good Kitaru fit, but
-  nobody has decided where waits, replay anchors, or side effects should live.
+  nobody has decided where waits, replay anchors, memory boundaries, or side
+  effects should live.
 
 Your value is to turn that fog into a practical architecture.
 
@@ -44,17 +47,23 @@ Kitaru is a durable execution layer for Python workflows built around four
 user-facing surfaces:
 
 - **SDK primitives**: `@flow`, `@checkpoint`, `wait()`, `log()`, `save()`,
-  `load()`, `llm()`, plus configuration helpers (`configure`, `connect`,
-  `create_stack`, `list_stacks`, `current_stack`, `use_stack`, `delete_stack`)
-- **KitaruClient** (inspection and control of existing executions):
-  `executions.get / list / latest / logs / pending_waits / input / abort_wait /
-  retry / resume / replay / cancel`, plus `artifacts.list / get`
+  `load()`, `llm()`, `memory.configure()`, `memory.set()`, `memory.get()`,
+  `memory.list()`, `memory.history()`, `memory.delete()`, plus configuration
+  helpers (`configure`, `connect`, `create_stack`, `list_stacks`,
+  `current_stack`, `use_stack`, `delete_stack`)
+- **KitaruClient** (inspection and control of existing executions plus explicit
+  memory/artifact administration): `executions.get / list / latest / logs /
+  pending_waits / input / abort_wait / retry / resume / replay / cancel`,
+  `artifacts.list / get`, and `memories.get / list / history / set / delete /
+  scopes`
 - **CLI control**: `kitaru login`, `kitaru run`, `kitaru executions ...`,
-  stack/model/secret commands (including remote stack creation for `kubernetes`,
-  `vertex`, `sagemaker`, `azureml`), and runtime inspection commands
+  `kitaru memory ...`, stack/model/secret commands (including remote stack
+  creation for `kubernetes`, `vertex`, `sagemaker`, `azureml`), and runtime
+  inspection commands
 - **MCP control**: execution tools (`kitaru_executions_list/get/latest/run/
-  input/retry/replay/cancel`), artifact tools, status, stack listing, and
-  `manage_stack` (create/delete including remote stacks)
+  input/retry/replay/cancel`), memory tools (`kitaru_memory_list/get/set/
+  delete/history`), artifact tools, status, stack listing, and `manage_stack`
+  (create/delete including remote stacks)
 
 It also ships a **PydanticAI adapter** (`wrap(...)`, `hitl_tool(...)`) for agent
 workloads that want Kitaru tracking without rewriting the whole control flow.
@@ -85,6 +94,8 @@ Design operator workflows around `input` as the primary action, not `resume`.
 
 That means naming matters. Stable checkpoint names become the handles people use
 later for replay. Stable wait names become the handles for operational input.
+Stable memory scopes and important keys become the handles people use to inspect
+or patch durable state later.
 
 ### Surface ownership
 
@@ -93,6 +104,8 @@ Not every surface can do every job:
 - **Launching executions**: SDK flow objects (`.run()`), CLI
   (`kitaru run`), MCP (`kitaru_executions_run`) — **not** `KitaruClient`
 - **Inspecting/controlling executions**: `KitaruClient`, CLI, MCP
+- **Using module-level memory inside flow code**: SDK `kitaru.memory`
+- **Explicit-scope memory administration**: `KitaruClient`, CLI, MCP
 - **Creating remote stacks**: CLI (`kitaru stack create`) and MCP
   (`manage_stack`) — the Python SDK `create_stack(...)` is **local stacks only**
 - **Artifact browsing**: `KitaruClient` and MCP — not the CLI
@@ -124,11 +137,27 @@ Listen for:
 - External systems: GitHub, email, databases, deployment targets, APIs
 - Data flow: what needs to persist between steps or executions
 - Failure points: where things break or must be resumed safely
-- Operator needs: who will inspect logs, replay work, submit wait input, or
-  cancel runs later
+- Operator needs: who will inspect logs, replay work, submit wait input, seed
+  or edit durable state, or cancel runs later
 
 If the answer is thin, ask targeted follow-ups about side effects, human
-intervention, and failure recovery.
+intervention, durable shared state, and failure recovery.
+
+### Memory-oriented discovery questions
+
+Ask these when the workflow appears to need state beyond one execution:
+
+- What information must survive across executions?
+- Should that information be fetched by stable key, or is it really tied to one
+  execution output?
+- Who will seed or edit that state: flow code, admin scripts, a human operator,
+  or an MCP assistant?
+- Does the state belong at **namespace**, **flow**, or **execution** scope?
+- Does the workflow need replay-frozen values, or is "latest durable state"
+  acceptable?
+
+These questions help you decide whether the design wants **memory** or
+**artifacts**.
 
 ## Phase 2: Assess fit
 
@@ -141,7 +170,7 @@ Determine whether Kitaru is actually the right tool.
 - Human approval or correction points that must survive process restarts
 - Multi-step workflows that benefit from replay after a checkpoint
 - Operational debugging needs: logs, artifacts, execution history, audit trail
-- Clear side-effect boundaries where a durable plan-then-commit pattern helps
+- Durable shared state that should survive across executions under stable keys
 
 ### Signals that Kitaru may be unnecessary
 
@@ -179,6 +208,7 @@ steps.
 - nested checkpoint calls
 - tiny internal model/tool calls inside a PydanticAI run that are already traced
   as child events
+- memory operations that belong in the flow body
 
 ### Real runtime constraints to respect
 
@@ -188,6 +218,12 @@ These are not style preferences. They are actual implementation boundaries.
 - Checkpoints do not nest.
 - `wait()` can only run in the flow body, never inside a checkpoint.
 - `save()` and `load()` require checkpoint scope.
+- `kitaru.memory.*` is allowed in flow scope, but forbidden inside a
+  checkpoint.
+- Outside a flow, module-level memory use requires `memory.configure(scope=...)`
+  first.
+- Module-level memory uses the active configured scope; explicit `scope=` lives
+  on client/CLI/MCP surfaces instead.
 - `log()` can run in flow scope or checkpoint scope.
 - `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
   synthetic `llm_call` checkpoint automatically.
@@ -210,6 +246,44 @@ Examples:
 Keep wait schemas simple and keep wait names stable. Those names become the
 handles operators use to provide input (via `client.executions.input(...)`,
 `kitaru executions input`, or MCP `kitaru_executions_input`).
+
+### Memory vs artifacts
+
+This is one of the most important design choices.
+
+Use **memory** when the workflow needs durable shared state addressed by stable
+`key + scope` names.
+
+Use **artifacts** when the value is an execution output or replay/debug boundary
+that should stay tied to a specific run or checkpoint.
+
+A simple test:
+
+- If the workflow needs "the current repo style guide" or "the latest customer
+  preference", that smells like **memory**.
+- If the workflow needs "the exact draft produced in execution X" or "the exact
+  retrieval output from checkpoint Y", that smells like an **artifact**.
+
+Do not silently substitute memory for explicit checkpoint outputs. Memory is not
+a drop-in replacement for replay-stable artifacts.
+
+### Memory scope design
+
+When memory is the right fit, choose the scope deliberately:
+
+- **namespace**: shared durable state across many executions, users, or agents
+- **flow**: state that naturally belongs to one flow name
+- **execution**: state isolated to one run but still key-addressable
+
+Important asymmetry to remember:
+
+- Module-level `kitaru.memory` uses an **active scope** set by
+  `memory.configure(...)` or the active flow name
+- `KitaruClient.memories`, CLI memory commands, and MCP memory tools use
+  **explicit scope** on each operation
+
+Stable scope names become operator handles just like checkpoint and wait names
+become operator handles.
 
 ### Side effects
 
@@ -238,13 +312,18 @@ Ask which surface will be used for each job:
 - replay from a checkpoint
 - cancel a stuck run
 - inspect artifacts
+- seed memory
+- inspect or edit memory
+- list memory scopes
 - create/manage stacks
 
 Use these rules:
 
 - **SDK flow objects** for launching new executions from Python code
+- **SDK `kitaru.memory`** for in-flow memory usage and outside-flow scripts that
+  can work with one active configured scope
 - **KitaruClient** for programmatic inspection and control of existing
-  executions (not for launching)
+  executions, plus explicit-scope memory administration
 - **CLI** for human operators and shell-based workflows; also the only way to
   log in with managed workspace names/IDs
 - **MCP** for agent tools and LLM-assisted operations
@@ -264,6 +343,17 @@ Important asymmetries to account for in the design:
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
 
+### Memory-specific asymmetries
+
+| Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
+|---|---|---|---|---|
+| Use memory inside flow code | Yes | No | No | No |
+| Outside-flow memory script writes | Yes, after `memory.configure(...)` | Yes | No | No |
+| Explicit-scope admin | Limited | Yes | Yes | Yes |
+| List scopes | No | Yes (`memories.scopes()`) | Yes (`kitaru memory scopes`) | No |
+| Versioned read | Yes (`memory.get(version=...)`) | Yes | No | Yes |
+| Prefix list | No | Yes (`memories.list(..., prefix=...)`) | No | Yes |
+
 ## Phase 5: Replay strategy
 
 Ask explicitly: "If this workflow fails or the requirements change, where would
@@ -281,6 +371,18 @@ Then design replay anchors deliberately.
 - If the replayed execution reaches a wait, resolve it operationally via
   `input`, not via override keys
 - Duplicate or vague names make replay painful later
+
+### Memory replay caveat
+
+Memory is durable, but it is not fully replay-frozen in the current release.
+
+That means:
+
+- replayed reads may observe newer memory values than the source execution saw
+- replayed writes create new memory versions
+
+If the user needs frozen replay semantics for a critical input, keep that input
+as an explicit checkpoint output/artifact instead of shared memory.
 
 When scoping, write down which checkpoint names are intended to be stable public
 replay selectors.
@@ -312,9 +414,14 @@ Review the proposed design for these smells:
 - too many tiny checkpoints
 - waits buried inside logic that belongs in the flow body
 - nested checkpoints or attempts to call flows from flows
+- memory operations planned inside checkpoints
+- memory used where replay-frozen artifacts are required
+- module-level memory designs that assume per-call `scope=`
+- CLI or MCP operator plans that assume default memory scope inference
 - side effects mixed into planning checkpoints
 - artifact sharing with no naming strategy
 - replay needs discussed abstractly but no concrete checkpoint names chosen
+- memory scopes or keys left vague even though operators must inspect them later
 - assuming CLI, client, and MCP all expose the same controls
 - using `KitaruClient` to launch executions (it can't — use flow objects)
 - using SDK `create_stack(...)` for remote stacks (it's local-only)
@@ -332,6 +439,7 @@ The MVP should usually have:
 - 2-4 checkpoints
 - at most one wait unless human review is the core product
 - one clear operator surface for the main operational tasks
+- a deliberate memory decision (yes/no, and why)
 - a small set of stable replay anchors (checkpoint names)
 - output that is genuinely useful on its own
 
@@ -368,7 +476,18 @@ guide.
 - **Resume**: [KitaruClient | CLI] (not MCP)
 - **Replay / cancel**: [surface]
 - **Artifact inspection**: [KitaruClient | MCP] (not CLI)
+- **Memory seed/update**: [SDK module API | KitaruClient | CLI | MCP]
+- **Memory inspection**: [KitaruClient | CLI | MCP]
+- **Memory scope listing**: [KitaruClient | CLI]
 - **Stack management**: [SDK (local only) | CLI (local + remote) | MCP (local + remote)]
+
+## Memory Strategy
+- **Use memory?**: [yes/no]
+- **Why memory vs artifacts?**: [brief reasoning]
+- **Scopes**: [scope -> scope_type -> owner]
+- **Keys**: [stable keys and what they store]
+- **Seed/update surfaces**: [module API | KitaruClient | CLI | MCP]
+- **Replay caveat**: [if relevant]
 
 ## Flow Design
 
@@ -390,11 +509,13 @@ guide.
 
 ## Cross-Flow Data
 [If multiple flows exist, explain what artifacts are shared, who consumes them,
-and **how downstream flows obtain upstream execution IDs** for `load(...)` calls]
+and how downstream flows obtain upstream execution IDs for `load(...)` calls. If
+memory is shared across flows, name the scopes and key owners explicitly.]
 
 ## Naming Strategy
 - **Stable checkpoint names** (replay anchors): [...]
 - **Stable wait names** (operator input handles): [...]
+- **Stable memory scopes / keys**: [...]
 - **Artifact naming rules**: [...]
 
 ## Deferred / Future Work
@@ -410,8 +531,8 @@ Once the document is ready:
 
 1. Show it to the user and ask what should change
 2. Offer the next step: implement the MVP flow with `kitaru-authoring`
-3. Carry forward the chosen checkpoint names, wait names, replay anchors, and
-   operator surfaces into implementation
+3. Carry forward the chosen checkpoint names, wait names, replay anchors,
+   memory decisions, memory scopes, and operator surfaces into implementation
 
 ## Readiness check
 

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -51,19 +51,22 @@ user-facing surfaces:
   `memory.list()`, `memory.history()`, `memory.delete()`, plus configuration
   helpers (`configure`, `connect`, `create_stack`, `list_stacks`,
   `current_stack`, `use_stack`, `delete_stack`)
-- **KitaruClient** (inspection and control of existing executions plus explicit
+- **KitaruClient** (inspection/control plus explicit typed-scope
   memory/artifact administration): `executions.get / list / latest / logs /
   pending_waits / input / abort_wait / retry / resume / replay / cancel`,
   `artifacts.list / get`, and `memories.get / list / history / set / delete /
-  scopes`
+  scopes / compact / purge / purge_scope / compaction_log / reindex`
 - **CLI control**: `kitaru login`, `kitaru run`, `kitaru executions ...`,
-  `kitaru memory ...`, stack/model/secret commands (including remote stack
+  `kitaru memory scopes/list/get/set/delete/history/compact/purge/purge-scope/
+  compaction-log/reindex`, stack/model/secret commands (including remote stack
   creation for `kubernetes`, `vertex`, `sagemaker`, `azureml`), and runtime
   inspection commands
 - **MCP control**: execution tools (`kitaru_executions_list/get/latest/run/
   input/retry/replay/cancel`), memory tools (`kitaru_memory_list/get/set/
-  delete/history`), artifact tools, status, stack listing, and `manage_stack`
-  (create/delete including remote stacks)
+  delete/history/compact/purge/purge_scope/compaction_log`), artifact tools,
+  status, stack listing, and `manage_stack` (create/delete including remote
+  stacks). MCP memory can operate on a known typed scope, but cannot list memory
+  scopes or reindex historical memory tags.
 
 It also ships a **PydanticAI adapter** (`wrap(...)`, `hitl_tool(...)`) for agent
 workloads that want Kitaru tracking without rewriting the whole control flow.
@@ -94,8 +97,8 @@ Design operator workflows around `input` as the primary action, not `resume`.
 
 That means naming matters. Stable checkpoint names become the handles people use
 later for replay. Stable wait names become the handles for operational input.
-Stable memory scopes and important keys become the handles people use to inspect
-or patch durable state later.
+Stable memory typed scopes (`scope_type` + `scope`) and important keys become
+the handles people use to inspect or patch durable state later.
 
 ### Surface ownership
 
@@ -105,7 +108,7 @@ Not every surface can do every job:
   (`kitaru run`), MCP (`kitaru_executions_run`) — **not** `KitaruClient`
 - **Inspecting/controlling executions**: `KitaruClient`, CLI, MCP
 - **Using module-level memory inside flow code**: SDK `kitaru.memory`
-- **Explicit-scope memory administration**: `KitaruClient`, CLI, MCP
+- **Explicit typed-scope memory administration**: `KitaruClient`, CLI, MCP
 - **Creating remote stacks**: CLI (`kitaru stack create`) and MCP
   (`manage_stack`) — the Python SDK `create_stack(...)` is **local stacks only**
 - **Artifact browsing**: `KitaruClient` and MCP — not the CLI
@@ -152,9 +155,16 @@ Ask these when the workflow appears to need state beyond one execution:
   execution output?
 - Who will seed or edit that state: flow code, admin scripts, a human operator,
   or an MCP assistant?
-- Does the state belong at **namespace**, **flow**, or **execution** scope?
+- Which typed scope owns each key: **namespace**, **flow**, or **execution**?
+- What exact `scope` value will operators use with that `scope_type`?
 - Does the workflow need replay-frozen values, or is "latest durable state"
   acceptable?
+- Will the state need maintenance later: compaction, purge, purge-scope,
+  compaction-log inspection, or project-level reindexing?
+- If purge/purge-scope is needed, what retention rule applies: keep all history,
+  keep newest N, or include tombstoned keys?
+- If compact is needed, will the target environment have a default LLM model or
+  an explicit model configured?
 
 These questions help you decide whether the design wants **memory** or
 **artifacts**.
@@ -220,10 +230,10 @@ These are not style preferences. They are actual implementation boundaries.
 - `save()` and `load()` require checkpoint scope.
 - `kitaru.memory.*` is allowed in flow scope, but forbidden inside a
   checkpoint.
-- Outside a flow, module-level memory use requires `memory.configure(scope=...)`
-  first.
-- Module-level memory uses the active configured scope; explicit `scope=` lives
-  on client/CLI/MCP surfaces instead.
+- Outside a flow, module-level memory use requires configuring an active scope
+  first; `memory.configure(scope=...)` defaults to `scope_type="namespace"`.
+- Module-level memory uses the active configured typed scope; explicit `scope=`
+  and `scope_type=` live on client/CLI/MCP surfaces instead.
 - `log()` can run in flow scope or checkpoint scope.
 - `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
   synthetic `llm_call` checkpoint automatically.
@@ -252,7 +262,7 @@ handles operators use to provide input (via `client.executions.input(...)`,
 This is one of the most important design choices.
 
 Use **memory** when the workflow needs durable shared state addressed by stable
-`key + scope` names.
+`scope_type + scope + key` names.
 
 Use **artifacts** when the value is an execution output or replay/debug boundary
 that should stay tied to a specific run or checkpoint.
@@ -277,13 +287,22 @@ When memory is the right fit, choose the scope deliberately:
 
 Important asymmetry to remember:
 
-- Module-level `kitaru.memory` uses an **active scope** set by
-  `memory.configure(...)` or the active flow name
+- Module-level `kitaru.memory` uses an **active typed scope** set by
+  `memory.configure(...)` or inferred from the active flow
 - `KitaruClient.memories`, CLI memory commands, and MCP memory tools use
-  **explicit scope** on each operation
+  **explicit typed scope** (`scope_type` + `scope`) on each scoped operation
+- CLI scoped memory commands require both `--scope` and `--scope-type`
+- MCP can read/write/compact/purge a known typed scope, but cannot list memory
+  scopes or run reindex; do not choose MCP as the only operator surface if the
+  operator must discover scopes
 
-Stable scope names become operator handles just like checkpoint and wait names
-become operator handles.
+For execution-scoped memory, distinguish membership from producer provenance: a
+detached admin write can target `scope_type="execution"` plus
+`scope=<execution_id>` after a run finishes, so it belongs to that execution
+bucket even if that memory version was not produced during the live flow.
+
+Stable typed scope names become operator handles just like checkpoint and wait
+names become operator handles.
 
 ### Side effects
 
@@ -315,15 +334,17 @@ Ask which surface will be used for each job:
 - seed memory
 - inspect or edit memory
 - list memory scopes
+- read memory versions or prefix-filter memory lists
+- compact, purge, inspect compaction logs, or reindex memory
 - create/manage stacks
 
 Use these rules:
 
 - **SDK flow objects** for launching new executions from Python code
 - **SDK `kitaru.memory`** for in-flow memory usage and outside-flow scripts that
-  can work with one active configured scope
+  can work with one active configured typed scope
 - **KitaruClient** for programmatic inspection and control of existing
-  executions, plus explicit-scope memory administration
+  executions, plus explicit typed-scope memory administration
 - **CLI** for human operators and shell-based workflows; also the only way to
   log in with managed workspace names/IDs
 - **MCP** for agent tools and LLM-assisted operations
@@ -347,12 +368,25 @@ Important asymmetries to account for in the design:
 
 | Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
 |---|---|---|---|---|
-| Use memory inside flow code | Yes | No | No | No |
-| Outside-flow memory script writes | Yes, after `memory.configure(...)` | Yes | No | No |
-| Explicit-scope admin | Limited | Yes | Yes | Yes |
-| List scopes | No | Yes (`memories.scopes()`) | Yes (`kitaru memory scopes`) | No |
-| Versioned read | Yes (`memory.get(version=...)`) | Yes | No | Yes |
-| Prefix list | No | Yes (`memories.list(..., prefix=...)`) | No | Yes |
+| In-flow memory reads/writes | Yes | No | No | No |
+| Outside-flow seed/update | Yes, after `configure(...)` | Yes | Yes | Yes |
+| Active-scope Python API | Yes | No | No | No |
+| Explicit typed-scope operations | No | Yes | Yes | Yes |
+| List memory scopes | No | Yes | Yes | No |
+| Versioned reads | Yes | Yes | No | Yes |
+| Prefix listing | No | Yes | No | Yes |
+| Compact / purge / compaction log | No | Yes | Yes | Yes |
+| Reindex historical tags | No | Yes | Yes | No |
+
+Memory maintenance has different jobs:
+
+- `compact` sends selected memory values to an LLM and writes a summary as a new
+  memory version. It does not delete source entries.
+- `purge` / `purge_scope` physically delete old versions. `keep=1` keeps the
+  newest selected version; omitting `keep` deletes all selected versions.
+- `compaction_log` reads the audit trail for compact and purge operations.
+- `reindex` is project-scoped, dry-run by default, additive tag backfill for
+  historical memory discovery. It is not cleanup and does not rewrite values.
 
 ## Phase 5: Replay strategy
 
@@ -418,6 +452,18 @@ Review the proposed design for these smells:
 - memory used where replay-frozen artifacts are required
 - module-level memory designs that assume per-call `scope=`
 - CLI or MCP operator plans that assume default memory scope inference
+- memory scopes named without a `scope_type`
+- choosing CLI as the only memory inspection surface when versioned reads or
+  prefix filtering are required
+- choosing MCP as the memory operator surface without providing exact
+  `scope_type` + `scope` values
+- assuming MCP can list memory scopes or run reindex
+- designing memory maintenance but assigning it to module-level `kitaru.memory`
+- treating `compact` as cleanup instead of summary-writing; purge is the
+  separate hard-delete step
+- treating `delete` and `purge` as interchangeable cleanup operations
+- forgetting that `memory reindex` is project-scoped, additive tag backfill, not
+  a value rewrite or cleanup operation
 - side effects mixed into planning checkpoints
 - artifact sharing with no naming strategy
 - replay needs discussed abstractly but no concrete checkpoint names chosen
@@ -478,15 +524,25 @@ guide.
 - **Artifact inspection**: [KitaruClient | MCP] (not CLI)
 - **Memory seed/update**: [SDK module API | KitaruClient | CLI | MCP]
 - **Memory inspection**: [KitaruClient | CLI | MCP]
-- **Memory scope listing**: [KitaruClient | CLI]
+- **Memory scope listing**: [KitaruClient | CLI] (not MCP)
+- **Memory maintenance**: [KitaruClient | CLI | MCP for compact/purge/log;
+  KitaruClient | CLI for reindex]
 - **Stack management**: [SDK (local only) | CLI (local + remote) | MCP (local + remote)]
 
 ## Memory Strategy
 - **Use memory?**: [yes/no]
 - **Why memory vs artifacts?**: [brief reasoning]
-- **Scopes**: [scope -> scope_type -> owner]
+- **Typed scopes**: [`scope_type` + `scope` -> owner/operator surface]
 - **Keys**: [stable keys and what they store]
 - **Seed/update surfaces**: [module API | KitaruClient | CLI | MCP]
+- **Maintenance**: [none | compact | purge | purge-scope | compaction-log |
+  reindex; who runs it]
+- **Retention policy**: [keep all history | keep newest N | purge tombstoned
+  keys | other]
+- **Inspection constraints**: [scope listing? versioned read? prefix list?
+  chosen surface]
+- **MCP scope handoff**: [if MCP is used, where exact `scope_type` + `scope`
+  values come from]
 - **Replay caveat**: [if relevant]
 
 ## Flow Design


### PR DESCRIPTION
## Summary

- Adds comprehensive `kitaru.memory` documentation and guidance to both the **kitaru-scoping** and **kitaru-authoring** skills
- Adds the new **kitaru-quickstart** skill for interactive onboarding, including a personalized demo flow, crash/replay walkthrough, wait(), durable memory, and optional MCP setup
- Covers the full memory surface: `memory.configure()`, `memory.set()`, `memory.get()`, `memory.list()`, `memory.history()`, `memory.delete()` in the SDK, plus `KitaruClient.memories`, CLI `kitaru memory ...` commands, and MCP `kitaru_memory_*` tools
- Adds memory-vs-artifact design guidance, typed memory scope design (`scope_type` + `scope`), memory-specific surface asymmetry tables, replay caveats, anti-patterns, and interview discovery questions
- Updates README with the three-skill workflow: quickstart → scope → author

## Details

The `kitaru.memory` feature is a new durable shared state primitive in Kitaru. These skill updates ensure that Claude Code can correctly guide users through:

1. **Quickstart** — building a small runnable demo that shows crash recovery, replay, human input with `wait()`, durable memory across executions, and optional MCP integration
2. **Scoping** — deciding whether shared state should use memory or artifacts, choosing typed scopes, and designing stable key/scope naming strategies
3. **Authoring** — writing correct memory code (flow body only, not inside checkpoints), configuring scopes outside flows, and using the right surface for memory administration

## Update

This PR now also includes the `/kitaru-quickstart` onboarding skill that was merged into the feature branch after the original memory-skill work. The quickstart guidance has been aligned with the current memory behavior as well: CLI examples use `--scope` plus `--scope-type`, and the MCP reference includes typed-scope memory tools and maintenance operations.

## Blocked on

**Do not merge** until [zenml-io/kitaru#82](https://github.com/zenml-io/kitaru/pull/82) is merged and released — that PR adds the memory feature to the core Kitaru SDK that these skills document.

## Test plan

- [ ] Verify skills load correctly in Claude Code after install
- [ ] Test quickstart skill with the five-minute tour — confirm demo scaffolding, crash recovery, and replay flow work
- [ ] Test quickstart guided build memory inspection — confirm CLI examples include `--scope-type flow`
- [ ] Test scoping skill with a workflow that needs cross-execution state — confirm memory discovery questions surface
- [ ] Test authoring skill with memory code generation — confirm correct scope/constraint guidance
- [ ] Confirm memory anti-patterns (e.g., memory inside checkpoints) are flagged
