### PR TITLE
Add `/kitaru-quickstart` skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "kitaru",
-      "source": ".",
+      "source": "./",
       "description": "Kitaru skills for Claude Code: scoping (flow architecture design) and authoring (writing durable agent workflows)"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
   "description": "Kitaru skills for Claude Code: scoping (flow architecture design) and authoring (writing durable agent workflows)",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+This repository is a Claude Code plugin, not a Python package. Keep contributor work focused on the plugin metadata and skill documents:
+
+- `skills/kitaru-scoping/SKILL.md` defines the workflow-scoping skill.
+- `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
+- `.claude-plugin/plugin.json` contains plugin metadata such as name, version, and repository URL.
+- `.claude-plugin/marketplace.json` defines the marketplace entry used for local/plugin testing.
+- `README.md` is the public-facing usage and installation guide.
+
+When adding a new skill, follow the existing pattern: `skills/<skill-name>/SKILL.md`.
+
+## Build, Test, and Development Commands
+There is no build step in this repo. Most contributor work is editing Markdown and JSON, then doing a quick manual validation.
+
+- `rg --files` lists the complete tracked file set.
+- `sed -n '1,160p' skills/kitaru-authoring/SKILL.md` previews a skill without opening an editor.
+- `git diff --stat` gives a compact review of changed files.
+- `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
+
+For manual smoke testing, follow the install commands in [`README.md`](README.md) and verify the plugin exposes `/kitaru-scoping` and `/kitaru-authoring`.
+
+## Coding Style & Naming Conventions
+Use Markdown for prose and JSON for plugin metadata. Match the existing style:
+
+- Use concise headings and short paragraphs.
+- Wrap lines at a readable width similar to the current files.
+- Keep examples concrete and technically accurate.
+- Use kebab-case for skill directory names and slash commands, for example `kitaru-scoping`.
+- Preserve valid JSON with two-space indentation in `.claude-plugin/*.json`.
+
+## Testing Guidelines
+There is currently no dedicated automated test suite. Treat testing as documentation validation:
+
+- Check that examples match the current Kitaru API surface.
+- Confirm new trigger phrases and command names are consistent across `SKILL.md`, `README.md`, and plugin metadata.
+- Re-read edited Markdown in rendered form when possible to catch broken lists, code fences, or tables.
+
+## Commit & Pull Request Guidelines
+Recent history uses short, imperative commit messages such as `Update skills for Kitaru memory support` and `Align skills with current Kitaru SDK surface`. Follow that pattern.
+
+Pull requests should explain what changed, why it changed, and which files were updated. If you alter behavior or installation steps, update `README.md` in the same PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 ## Project Structure & Module Organization
 This repository is a Claude Code plugin, not a Python package. Keep contributor work focused on the plugin metadata and skill documents:
 
+- `skills/kitaru-quickstart/SKILL.md` defines the interactive onboarding skill.
 - `skills/kitaru-scoping/SKILL.md` defines the workflow-scoping skill.
 - `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
 - `.claude-plugin/plugin.json` contains plugin metadata such as name, version, and repository URL.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repo is
+
+This is a **Claude Code skills plugin** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows. It contains no application code; the deliverables are two Markdown skill files that teach Claude Code how to scope and author Kitaru workflows.
+
+The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-skills`.
+
+## Repository structure
+
+```
+.claude-plugin/
+  plugin.json         # Plugin identity, version, keywords
+  marketplace.json    # Marketplace listing metadata
+skills/
+  kitaru-scoping/SKILL.md    # Structured interview → flow_architecture.md
+  kitaru-authoring/SKILL.md  # Authoring guide for flows, checkpoints, waits, memory, etc.
+```
+
+- **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
+- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
+
+The intended user workflow is: scope first → author second.
+
+## How to work on this repo
+
+There is no build step, no linter, no test suite. The deliverables are the two `SKILL.md` files. Quality comes from:
+
+1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
+2. **Completeness of asymmetry tables** — the skills document capability differences across four surfaces (SDK, KitaruClient, CLI, MCP). These tables must stay synchronized between the two skill files.
+3. **Stable naming** — checkpoint names, wait names, memory scopes, and operator handles are first-class concepts. Changes to naming conventions in the skills ripple into generated architecture documents.
+
+## Key constraints when editing skills
+
+- The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
+- Both skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the other.
+- The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
+- Plugin version is in `.claude-plugin/plugin.json` — bump it when publishing updates.
+
+## Installation methods (for testing)
+
+```bash
+# Marketplace
+/plugin marketplace add zenml-io/kitaru-skills
+/plugin install kitaru@kitaru
+
+# Manual (for local development)
+mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+cp skills/kitaru-scoping/SKILL.md .claude/skills/kitaru-scoping/SKILL.md
+cp skills/kitaru-authoring/SKILL.md .claude/skills/kitaru-authoring/SKILL.md
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,17 @@ The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-sk
   plugin.json         # Plugin identity, version, keywords
   marketplace.json    # Marketplace listing metadata
 skills/
-  kitaru-scoping/SKILL.md    # Structured interview → flow_architecture.md
-  kitaru-authoring/SKILL.md  # Authoring guide for flows, checkpoints, waits, memory, etc.
+  kitaru-quickstart/SKILL.md       # Interactive onboarding → demo flow
+  kitaru-quickstart/references/    # Track templates, host guides, MCP config
+  kitaru-scoping/SKILL.md          # Structured interview → flow_architecture.md
+  kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, memory, etc.
 ```
 
+- **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory, and optional MCP integration.
 - **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
 - **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
 
-The intended user workflow is: scope first → author second.
+The intended user workflow is: quickstart → scope → author.
 
 ## How to work on this repo
 
@@ -35,8 +38,9 @@ There is no build step, no linter, no test suite. The deliverables are the two `
 ## Key constraints when editing skills
 
 - The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
-- Both skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the other.
+- All three skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the others.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
+- The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
 - Plugin version is in `.claude-plugin/plugin.json` — bump it when publishing updates.
 
 ## Installation methods (for testing)
@@ -47,7 +51,8 @@ There is no build step, no linter, no test suite. The deliverables are the two `
 /plugin install kitaru@kitaru
 
 # Manual (for local development)
-mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+mkdir -p .claude/skills/kitaru-quickstart .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
+cp -r skills/kitaru-quickstart/ .claude/skills/kitaru-quickstart/
 cp skills/kitaru-scoping/SKILL.md .claude/skills/kitaru-scoping/SKILL.md
 cp skills/kitaru-authoring/SKILL.md .claude/skills/kitaru-authoring/SKILL.md
 ```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # Kitaru Skills for Claude Code
 
-Two [Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for
-designing and building durable AI agent workflows with
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for
+discovering, designing, and building durable AI agent workflows with
 [Kitaru](https://kitaru.ai).
 
 ## Skills
 
 | Skill | Slash command | Purpose |
 |---|---|---|
+| **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory across executions, and optional MCP integration |
 | **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory-vs-artifact strategy, memory scope design, operator surface, MVP scope) |
 | **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient.memories`, replay/resume/retry, CLI memory commands, MCP memory tools, and PydanticAI adapter integrations |
 
 ### Recommended workflow
 
-1. **Scope first** — use `/kitaru-scoping` to validate fit and define your flow
+1. **Quickstart** — use `/kitaru-quickstart` to see what Kitaru does and
+   build intuition for crash recovery, replay, wait, and memory
+2. **Scope** — use `/kitaru-scoping` to validate fit and define your flow
    architecture before writing code
-2. **Author second** — use `/kitaru-authoring` to build the flows defined in
+3. **Author** — use `/kitaru-authoring` to build the flows defined in
    your `flow_architecture.md`
 
 ## Installation
@@ -59,6 +62,12 @@ curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/
 ```
 
 ## Example prompts
+
+**Quickstart:**
+- "I want to try Kitaru — show me what it does."
+- "Give me a five-minute tour of Kitaru's crash recovery."
+- "Set up a Kitaru demo for my data pipeline workflow."
+- "Walk me through Kitaru with MCP integration."
 
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -1,0 +1,502 @@
+---
+name: kitaru-quickstart
+description: >
+  Interactive onboarding for new Kitaru users. Scaffolds a personalized demo
+  flow, demonstrates crash recovery with replay, human-in-the-loop with
+  wait(), durable memory across executions, and optional MCP integration.
+  Use when a user mentions kitaru quickstart, getting started with kitaru,
+  kitaru demo, kitaru onboarding, try kitaru, learn kitaru, what is kitaru,
+  show me kitaru, kitaru tutorial, or wants to see what Kitaru does.
+---
+
+# Kitaru Quickstart
+
+Build and run a working Kitaru demo tailored to the user's domain. Take
+someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
+wait, and memory" in a single session.
+
+> **Relationship to other skills**:
+> - `/kitaru-quickstart` → activation and intuition (this skill)
+> - `/kitaru-scoping` → design durability for a real workflow
+> - `/kitaru-authoring` → refactor production code with Kitaru primitives
+
+## Before you start
+
+Ask three questions using the structured question tool (`AskUserQuestion` in
+Claude Code, `request_user_input` in Codex) before generating any code. If
+no structured question tool exists, ask in chat with short numbered
+questions.
+
+### Question 1: Domain
+
+> Which workflow is closest to what you care about?
+
+- **Research/content** — gather → draft → approve → publish
+- **Coding agent** — analyze issue → generate patch → approve → merge
+- **Data pipeline** — ingest → validate → transform → load
+- **Support/triage** — classify → draft response → approve → escalate
+- **Other**
+
+If the user picks "other" and their use case does not map to any track,
+suggest they describe their architecture in the
+[ZenML Slack](https://zenml.io/slack) or open an issue on
+[zenml-io/kitaru](https://github.com/zenml-io/kitaru) so it can be scoped
+properly. Then default to the research/content track for the demo.
+
+### Question 2: Runtime
+
+> Which runtime should the demo use?
+
+- **Raw Python** (default) — no dependencies beyond Kitaru, uses mock
+  functions with `time.sleep()`
+- **PydanticAI** — uses `TestModel`, no API keys needed
+- **Simplest working path** — you choose
+
+For v1, use the raw Python track template regardless of choice. If the user
+specifically requests PydanticAI, complete the quickstart in raw Python and
+then offer `/kitaru-authoring` for PydanticAI conversion.
+
+### Question 3: Depth
+
+> How deep today?
+
+- **Five-minute tour** — crash → replay demo only
+- **Guided build** — full walkthrough
+- **Guided build + MCP** — full walkthrough with MCP integration
+
+## Depth routing
+
+| Depth              | Phases              |
+|--------------------|---------------------|
+| Five-minute tour   | 0 → 1 → 5          |
+| Guided build       | 0 → 1 → 2 → 2.5 → 3 → 5 |
+| Guided build + MCP | 0 → 1 → 2 → 2.5 → 3 → 4 → 5 |
+
+---
+
+## Phase 0: Environment setup
+
+1. **Check safety**: Is the current directory safe to modify?
+   - If it has `src/`, `.git` with uncommitted changes, `package.json`,
+     `pyproject.toml`, or other project markers: ask the user and default to
+     creating `./kitaru-quickstart-demo/`.
+   - If it is empty or a scratch directory: work here.
+
+2. **Verify Python**: `python3 --version` (require 3.10+)
+
+3. **Verify uv**: `uv --version`
+   - If missing, suggest:
+     `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+4. **Create project and install Kitaru**:
+   ```bash
+   mkdir -p kitaru-quickstart-demo
+   cd kitaru-quickstart-demo
+   uv init --no-workspace
+   uv add kitaru
+   ```
+
+5. **Initialize Kitaru**: `kitaru init`
+
+6. **Verify**: `kitaru status`
+
+If any step fails, explain the error, apply a fix, and retry once. If it
+fails again, present the error to the user and ask for guidance.
+
+---
+
+## Phase 1: Crash-and-replay demo
+
+This is the core activation sequence. It must feel dramatic, not academic.
+
+### Step 1: Load the track template
+
+Read the template from `references/tracks/{track}.py` based on the user's
+domain choice:
+
+| Domain          | Template file  | Flow name        |
+|-----------------|---------------|------------------|
+| Research/content| `research.py` | `research_flow`  |
+| Coding agent    | `coding.py`   | `coding_flow`    |
+| Data pipeline   | `data.py`     | `data_flow`      |
+| Support/triage  | `support.py`  | `support_flow`   |
+
+### Step 2: Customize the template
+
+Adapt variable names, mock data, and print statements to the user's domain.
+
+**CRITICAL**: Do NOT alter the placement, arguments, or syntax of `@flow`,
+`@checkpoint`, `wait()`, `log()`, or `memory.*` calls. Only customize the
+internal business logic of checkpoint functions (string content, mock data
+values, variable names).
+
+### Step 3: Write the customized flow
+
+Write the customized template to `demo_flow.py` in the project directory.
+The template includes a pre-baked crash marked with:
+
+```python
+# --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+raise Exception("Simulated ...")
+# --- end crash ---
+```
+
+### Step 4: Run the flow (it will crash)
+
+```bash
+uv run python demo_flow.py
+```
+
+Read the output. Verify you see a traceback at the second checkpoint.
+
+### Step 5: Explain the crash
+
+Tell the user:
+
+> "The flow crashed at the second checkpoint. In a traditional script,
+> everything from checkpoint 1 would be lost — you'd rerun the entire
+> pipeline and redo all that work. With Kitaru, checkpoint 1's output is
+> saved to the local SQLite database. Let's fix the crash and replay from
+> exactly where it broke."
+
+### Step 6: Fix the code
+
+Remove the lines between `# --- QUICKSTART CRASH ---` and
+`# --- end crash ---` from `demo_flow.py`.
+
+### Step 7: Get the execution ID
+
+From the crash output, or run:
+
+```bash
+kitaru executions list --output json
+```
+
+Extract the execution ID of the failed run.
+
+### Step 8: Replay from the failed checkpoint
+
+```bash
+kitaru executions replay <EXEC_ID> --from <CHECKPOINT_NAME>
+```
+
+Checkpoint names by track:
+
+| Track           | Replay from       |
+|-----------------|-------------------|
+| Research/content| `draft_content`   |
+| Coding agent    | `generate_patch`  |
+| Data pipeline   | `transform`       |
+| Support/triage  | `draft_response`  |
+
+### Step 9: Verify and explain
+
+Read the replay output. Verify that checkpoint 1 was loaded from cache (not
+re-executed). Then tell the user:
+
+> "Notice that the first checkpoint was loaded from cache and skipped —
+> only the second checkpoint onwards re-executed. That's crash recovery
+> with zero wasted work. In production, this means no burned tokens, no
+> repeated API calls, no lost progress."
+
+**Verification**: If the output does not show caching behavior, read the
+full output, diagnose the issue, and retry once.
+
+If the user chose **five-minute tour**, skip to **Phase 5**.
+
+---
+
+## Phase 2: Human-in-the-loop with `wait()`
+
+### Step 1: Run the flow again
+
+The crash is now fixed. Run the flow:
+
+```bash
+uv run python demo_flow.py
+```
+
+The flow will pause at the `wait()` gate.
+
+### Step 2: Explain the pause
+
+> "The flow is now paused at a wait gate. In production, your agent
+> releases compute while waiting — no idle containers burning money. The
+> execution state is safely persisted. A human (or another agent) can
+> provide input whenever they're ready."
+
+### Step 3: Provide input
+
+```bash
+kitaru executions input <EXEC_ID> --wait <WAIT_NAME> --value true
+```
+
+Wait names by track:
+
+| Track           | Wait name            |
+|-----------------|----------------------|
+| Research/content| `approve_draft`      |
+| Coding agent    | `approve_merge`      |
+| Data pipeline   | `approve_load`       |
+| Support/triage  | `approve_escalation` |
+
+### Step 4: Resume if needed
+
+If the execution does not auto-continue:
+
+```bash
+kitaru executions resume <EXEC_ID>
+```
+
+### Step 5: Verify completion
+
+Confirm the flow completed successfully and show the final output.
+
+---
+
+## Phase 2.5: Durable memory demo
+
+### Step 1: Explain memory
+
+> "Kitaru has durable memory — your flows can remember state across
+> executions. The flow you just ran stored some context. Let's run it
+> again with different input and watch it remember."
+
+### Step 2: Run the flow again with different input
+
+Choose a different argument that makes sense for the track:
+
+| Track           | Example second input             |
+|-----------------|----------------------------------|
+| Research/content| `"quantum computing"`            |
+| Coding agent    | `"optimize database query speed"`|
+| Data pipeline   | `"inventory_data_2026_q2.csv"`   |
+| Support/triage  | `"login page returns 500 error"` |
+
+```bash
+uv run python demo_flow.py "<new input>"
+```
+
+### Step 3: Point out the memory detection
+
+The flow logs should show it detected the previous input from memory. Point
+this out to the user.
+
+### Step 4: Inspect memory from the CLI
+
+```bash
+kitaru memory list --scope <FLOW_NAME>
+kitaru memory get last_topic --scope <FLOW_NAME>
+```
+
+Memory key names by track:
+
+| Track           | Flow name       | Memory key     |
+|-----------------|-----------------|----------------|
+| Research/content| `research_flow` | `last_topic`   |
+| Coding agent    | `coding_flow`   | `last_issue`   |
+| Data pipeline   | `data_flow`     | `last_source`  |
+| Support/triage  | `support_flow`  | `last_ticket`  |
+
+### Step 5: Explain
+
+> "Memory persists across executions under stable keys. Your agent can
+> accumulate knowledge, preferences, or context over time. Operators can
+> inspect or edit that state from the CLI, Python client, or MCP tools."
+
+---
+
+## Phase 3: Inspect and explore
+
+### Step 1: Show execution history
+
+```bash
+kitaru executions list
+```
+
+### Step 2: Inspect a specific execution
+
+```bash
+kitaru executions get <EXEC_ID>
+```
+
+### Step 3: View structured logs
+
+```bash
+kitaru executions logs <EXEC_ID>
+```
+
+### Step 4: Explain
+
+> "Every checkpoint, wait, memory operation, and log call is tracked.
+> This gives you full observability into what your agent did, when, and
+> why — without building custom logging infrastructure."
+
+---
+
+## Phase 4: MCP integration (opt-in)
+
+Only run this phase if the user chose **guided build + MCP**.
+
+### Step 1: Explain the value
+
+> "I can configure your environment so I can directly query Kitaru's
+> execution database, provide input to waiting flows, and trigger
+> replays — all through natural language."
+
+### Step 2: Detect the host
+
+Check filesystem markers:
+
+- `.claude/` → Claude Code
+- `.cursor/` or `.cursorignore` → Cursor
+- `.codex/` → Codex CLI
+
+If no markers found or multiple matches, ask the user which host they are
+using.
+
+### Step 3: Install the MCP extra
+
+```bash
+uv add kitaru --extra mcp
+```
+
+### Step 4: Load the host-specific guide
+
+Read the appropriate file from `references/hosts/{host}.md`:
+
+- Claude Code → `references/hosts/claude-code.md`
+- Cursor → `references/hosts/cursor.md`
+- Codex → `references/hosts/codex.md`
+- Copilot → `references/hosts/copilot.md`
+- Gemini → `references/hosts/gemini.md`
+
+### Step 5: Ask for explicit consent
+
+Before modifying any configuration file:
+
+1. Show the exact file path that will be created or modified.
+2. Show the exact content or diff that will be written.
+3. Ask for explicit approval.
+
+**Never write to MCP config files without consent.**
+
+### Step 6: Apply configuration
+
+Follow the host-specific guide to configure the MCP server.
+
+### Step 7: Demonstrate MCP tools
+
+Show at least 3 MCP tools in action against the demo flow:
+
+1. **List executions** — show the executions from earlier phases
+2. **Inspect execution** — read status and details of a specific run
+3. **Read logs** — show structured logs from a checkpoint
+
+If a wait is currently pending, also demonstrate:
+4. **Provide input** — resolve a wait via MCP
+
+If applicable:
+5. **Replay** — trigger a replay via MCP
+
+### Step 8: Handle failure
+
+If MCP installation or configuration fails:
+
+1. Read `references/mcp-config-guide.md`
+2. Explain the manual setup path to the user
+3. Continue to Phase 5 without MCP
+
+---
+
+## Phase 5: Handoff and next steps
+
+### Step 1: Write `KITARU_NEXT_STEPS.md`
+
+Write this file to the project directory, filling in the actual values from
+the session:
+
+```markdown
+# Kitaru Quickstart — What You Built
+
+## Demo summary
+- **Domain**: [user's chosen domain]
+- **Flow**: [flow name] with [N] checkpoints
+- **Demonstrated**: crash recovery, replay[, wait(), memory, MCP]
+
+## Kitaru primitives used
+
+| Primitive | What it does | Where you saw it |
+|---|---|---|
+| `@flow` | Durable orchestration boundary | `demo_flow.py` |
+| `@checkpoint` | Replay-safe unit of work | `demo_flow.py` |
+| `wait()` | Human-in-the-loop gate | `demo_flow.py` |
+| `log()` | Structured metadata | `demo_flow.py` |
+| `memory.set/get` | Cross-execution durable state | `demo_flow.py` |
+| `replay` | Re-execute from a checkpoint | CLI |
+
+## Next steps
+- **`/kitaru-scoping`** — Design durability for a real workflow
+- **`/kitaru-authoring`** — Refactor existing code with Kitaru primitives
+
+## Resources
+- [Kitaru documentation](https://kitaru.ai/docs)
+- [ZenML Slack](https://zenml.io/slack)
+- [Kitaru SDK repository](https://github.com/zenml-io/kitaru)
+```
+
+Adjust the "Demonstrated" line and primitives table based on which phases
+actually ran (five-minute tour only shows crash recovery and replay).
+
+### Step 2: Offer next steps
+
+> "Your quickstart is complete! Here's what you can do next:"
+>
+> - **`/kitaru-scoping`** if you want to design durability for a real
+>   workflow
+> - **`/kitaru-authoring`** if you have existing code you'd like to
+>   refactor with Kitaru primitives
+
+---
+
+## Guardrails
+
+Enforce these rules throughout the entire session:
+
+1. **Template integrity**: Never alter the placement, arguments, or syntax
+   of `@flow`, `@checkpoint`, `wait()`, `log()`, `memory.*`, `save()`, or
+   `load()` decorators or calls. Only customize the internal business
+   logic of checkpoint functions.
+
+2. **Scope limit**: Keep generated code under 150 lines. Use mock functions
+   with `time.sleep()` to simulate latency. Do not implement real API
+   connections or complex data processing.
+
+3. **Verification**: After every terminal command, read the output and
+   verify success before proceeding. Never assume a command worked.
+
+4. **Failure recovery**: If a step fails, explain the error, apply a fix,
+   and retry once. If it fails again, present the error to the user and
+   ask for guidance. Do not loop.
+
+5. **MCP consent**: Never write to MCP config files without showing the
+   user the exact diff and receiving explicit approval.
+
+6. **No blanket shell approval**: Do not request broad shell preapproval
+   from the user.
+
+7. **Memory placement**: `memory.*` calls belong in the flow body only,
+   never inside checkpoints.
+
+8. **Real commands only**: Use only documented Kitaru CLI commands:
+   - Replay: `kitaru executions replay <id> --from <checkpoint>`
+     (not `kitaru replay`)
+   - There is no `kitaru ui` command
+   - There is no top-level `kitaru run` command
+   - Wait input: `kitaru executions input <id> --wait <name> --value <val>`
+
+9. **No API key requirements**: The quickstart must run without any API
+   keys, cloud credentials, or external service accounts.
+
+10. **Checkpoint outputs must be serializable**: All mock return values from
+    checkpoints must be JSON-serializable (strings, numbers, lists, dicts).

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -284,19 +284,23 @@ this out to the user.
 
 ### Step 4: Inspect memory from the CLI
 
+The templates use module-level `kitaru.memory` inside the flow body, so the
+values live in the default flow typed scope. CLI inspection needs both the
+scope value and the scope type:
+
 ```bash
-kitaru memory list --scope <FLOW_NAME>
-kitaru memory get last_topic --scope <FLOW_NAME>
+kitaru memory list --scope <FLOW_NAME> --scope-type flow
+kitaru memory get <MEMORY_KEY> --scope <FLOW_NAME> --scope-type flow
 ```
 
-Memory key names by track:
+Memory scope and key names by track:
 
-| Track           | Flow name       | Memory key     |
-|-----------------|-----------------|----------------|
-| Research/content| `research_flow` | `last_topic`   |
-| Coding agent    | `coding_flow`   | `last_issue`   |
-| Data pipeline   | `data_flow`     | `last_source`  |
-| Support/triage  | `support_flow`  | `last_ticket`  |
+| Track            | Scope type | Scope value     | Memory key    |
+|------------------|------------|-----------------|---------------|
+| Research/content | `flow`     | `research_flow` | `last_topic`  |
+| Coding agent     | `flow`     | `coding_flow`   | `last_issue`  |
+| Data pipeline    | `flow`     | `data_flow`     | `last_source` |
+| Support/triage   | `flow`     | `support_flow`  | `last_ticket` |
 
 ### Step 5: Explain
 

--- a/skills/kitaru-quickstart/references/hosts/claude-code.md
+++ b/skills/kitaru-quickstart/references/hosts/claude-code.md
@@ -1,0 +1,46 @@
+# Claude Code — MCP Setup
+
+## Detection markers
+
+- `.claude/` directory exists
+- `.claude/settings.json` exists
+
+## Option A: CLI registration (recommended)
+
+```bash
+claude mcp add kitaru kitaru-mcp
+```
+
+This registers the Kitaru MCP server in Claude Code's project-scoped
+configuration. No file edits needed.
+
+## Option B: Project `.mcp.json` file
+
+Create or merge into `.mcp.json` at the project root:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+If `.mcp.json` already exists, merge the `kitaru` key into the existing
+`mcpServers` object. Do not overwrite other servers.
+
+## After setup
+
+Claude Code picks up MCP changes on the next message. No restart is needed.
+
+## Scopes
+
+Claude Code supports three configuration scopes:
+
+- **Project** (`.mcp.json` in project root) — recommended for quickstart
+- **User** (`~/.claude/settings.json`)
+- **Organization** (managed by team admin)
+
+The CLI `claude mcp add` command defaults to project scope.

--- a/skills/kitaru-quickstart/references/hosts/codex.md
+++ b/skills/kitaru-quickstart/references/hosts/codex.md
@@ -1,0 +1,34 @@
+# Codex CLI — MCP Setup
+
+## Detection markers
+
+- `.codex/` directory exists
+
+## Configuration
+
+Codex CLI MCP configuration is not yet authoritatively documented in the
+Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult the Codex CLI documentation for the correct MCP
+configuration path and format, then use `kitaru-mcp` as the server command.
+
+If the user knows their Codex MCP config location, the general pattern is:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/hosts/copilot.md
+++ b/skills/kitaru-quickstart/references/hosts/copilot.md
@@ -1,0 +1,23 @@
+# GitHub Copilot — MCP Setup
+
+## Detection markers
+
+No reliable filesystem markers for Copilot. Ask the user to confirm their
+host if Copilot is suspected.
+
+## Configuration
+
+GitHub Copilot MCP configuration is not yet authoritatively documented in
+the Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult GitHub Copilot documentation for MCP server
+registration, then use `kitaru-mcp` as the server command.
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/hosts/cursor.md
+++ b/skills/kitaru-quickstart/references/hosts/cursor.md
@@ -1,0 +1,31 @@
+# Cursor — MCP Setup
+
+## Detection markers
+
+- `.cursor/` directory exists
+- `.cursorignore` file exists
+- `.cursorindexingignore` file exists
+
+## Configuration
+
+Create or merge into `.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp",
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+If `.cursor/mcp.json` already exists, merge the `kitaru` key into the
+existing `mcpServers` object. Do not overwrite other servers.
+
+## After setup
+
+Cursor may need a reload to pick up MCP configuration changes. Suggest the
+user reload the window or restart Cursor if tools are not immediately
+available.

--- a/skills/kitaru-quickstart/references/hosts/gemini.md
+++ b/skills/kitaru-quickstart/references/hosts/gemini.md
@@ -1,0 +1,23 @@
+# Gemini CLI — MCP Setup
+
+## Detection markers
+
+No reliable filesystem markers for Gemini CLI. Ask the user to confirm
+their host if Gemini is suspected.
+
+## Configuration
+
+Gemini CLI MCP configuration is not yet authoritatively documented in the
+Kitaru repository. The Kitaru MCP server executable is:
+
+```
+kitaru-mcp
+```
+
+Suggest the user consult Gemini CLI documentation for MCP server
+registration, then use `kitaru-mcp` as the server command.
+
+## Fallback
+
+If MCP configuration is not straightforward, skip MCP setup and refer the
+user to `references/mcp-config-guide.md` for manual guidance.

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -74,16 +74,25 @@ Once configured, the Kitaru MCP server exposes these tools:
 - `kitaru_executions_replay` — replay from a checkpoint
 - `kitaru_executions_cancel` — cancel a running execution
 - `get_execution_logs` — read execution logs
-- `kitaru_memory_list` — list memory entries in a scope
-- `kitaru_memory_get` — read a memory value
+- `kitaru_memory_list` — list memory entries in a known typed scope
+- `kitaru_memory_get` — read a memory value from a known typed scope
 - `kitaru_memory_set` — write a memory value
-- `kitaru_memory_delete` — delete a memory key
+- `kitaru_memory_delete` — soft-delete a memory key
 - `kitaru_memory_history` — view version history for a key
+- `kitaru_memory_compact` — summarize memory values with an LLM
+- `kitaru_memory_purge` — physically delete old versions of one key
+- `kitaru_memory_purge_scope` — physically delete old versions across a scope
+- `kitaru_memory_compaction_log` — inspect compact/purge audit records
 - `kitaru_artifacts_list` — list artifacts for an execution
 - `kitaru_artifacts_get` — read an artifact
 - `kitaru_status` — check Kitaru connection status
 - `kitaru_stacks_list` — list available stacks
 - `manage_stack` — create or delete stacks
+
+Memory tools operate on explicit typed scopes: provide both `scope` and
+`scope_type` for scoped memory calls. `kitaru_memory_get` supports `version`,
+and `kitaru_memory_list` supports `prefix`. MCP can work with a known memory
+scope, but it does not currently expose memory scope listing or memory reindexing.
 
 ## Authentication
 

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -1,0 +1,94 @@
+# Kitaru MCP Server — Manual Setup Guide
+
+Use this guide when automatic host detection fails or when the user's host
+is not directly supported.
+
+## Install the MCP extra
+
+```bash
+uv add kitaru --extra mcp
+```
+
+Or with pip:
+
+```bash
+pip install "kitaru[mcp]"
+```
+
+## Verify installation
+
+```bash
+kitaru-mcp --help
+```
+
+If `kitaru-mcp` is not found, ensure the Python environment where Kitaru is
+installed is activated.
+
+## Server executable
+
+The MCP server command is:
+
+```
+kitaru-mcp
+```
+
+It uses stdio transport by default.
+
+## Generic MCP configuration
+
+Most hosts use a JSON configuration file with this schema:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp"
+    }
+  }
+}
+```
+
+Some hosts require an explicit transport field:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "kitaru-mcp",
+      "transport": "stdio"
+    }
+  }
+}
+```
+
+## Available MCP tools
+
+Once configured, the Kitaru MCP server exposes these tools:
+
+- `kitaru_executions_list` — list recent executions
+- `kitaru_executions_get` — inspect an execution
+- `kitaru_executions_latest` — get the most recent execution
+- `kitaru_executions_run` — run a flow
+- `kitaru_executions_input` — provide input to a waiting execution
+- `kitaru_executions_retry` — retry a failed execution
+- `kitaru_executions_replay` — replay from a checkpoint
+- `kitaru_executions_cancel` — cancel a running execution
+- `get_execution_logs` — read execution logs
+- `kitaru_memory_list` — list memory entries in a scope
+- `kitaru_memory_get` — read a memory value
+- `kitaru_memory_set` — write a memory value
+- `kitaru_memory_delete` — delete a memory key
+- `kitaru_memory_history` — view version history for a key
+- `kitaru_artifacts_list` — list artifacts for an execution
+- `kitaru_artifacts_get` — read an artifact
+- `kitaru_status` — check Kitaru connection status
+- `kitaru_stacks_list` — list available stacks
+- `manage_stack` — create or delete stacks
+
+## Authentication
+
+The MCP server uses the same authentication context as the Kitaru CLI. If
+you are logged in via `kitaru login`, the MCP server will use those
+credentials.
+
+For local-only usage (no remote server), no login is needed.

--- a/skills/kitaru-quickstart/references/tracks/coding.py
+++ b/skills/kitaru-quickstart/references/tracks/coding.py
@@ -1,0 +1,85 @@
+"""Coding agent flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: analyze issue → generate patch → approve → apply patch
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def analyze_issue(issue: str) -> dict:
+    """Simulate analyzing a code issue."""
+    log(step="analyze", issue=issue)
+    time.sleep(1)
+    return {
+        "issue": issue,
+        "files": ["src/main.py", "src/utils.py"],
+        "severity": "medium",
+        "root_cause": f"Incorrect handling of edge case in {issue}",
+    }
+
+
+@checkpoint
+def generate_patch(analysis: dict) -> str:
+    """Simulate generating a code patch."""
+    log(step="generate_patch", files=analysis["files"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated timeout calling code generation model")
+    # --- end crash ---
+    time.sleep(2)
+    patch = (
+        f"--- a/src/main.py\n"
+        f"+++ b/src/main.py\n"
+        f"@@ -42,3 +42,5 @@\n"
+        f"-    return process(data)\n"
+        f"+    if not data:\n"
+        f'+        raise ValueError("Empty input")\n'
+        f"+    return process(data)\n"
+    )
+    return patch
+
+
+@checkpoint
+def apply_patch(patch: str) -> str:
+    """Simulate applying the approved patch."""
+    log(step="apply", patch_length=len(patch))
+    time.sleep(1)
+    return f"Patch applied successfully ({len(patch)} chars)"
+
+
+@flow
+def coding_flow(issue: str) -> str:
+    """Analyze an issue, generate a patch, review, and apply it."""
+    previous_issue = memory.get("last_issue")
+    if previous_issue:
+        log(returning_user=True, previous_issue=previous_issue)
+
+    analysis = analyze_issue(issue)
+    patch = generate_patch(analysis)
+
+    approved = wait(
+        name="approve_merge",
+        question=f"Approve patch for '{issue}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Patch for '{issue}' was rejected"
+
+    result = apply_patch(patch)
+    memory.set("last_issue", issue)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    issue = sys.argv[1] if len(sys.argv) > 1 else "fix null pointer in data processor"
+    handle = coding_flow.run(issue)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/data.py
+++ b/skills/kitaru-quickstart/references/tracks/data.py
@@ -1,0 +1,102 @@
+"""Data pipeline flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: ingest → validate → transform → approve → load
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def ingest(source: str) -> list[dict]:
+    """Simulate ingesting raw data from a source."""
+    log(step="ingest", source=source)
+    time.sleep(1)
+    return [
+        {"id": 1, "value": 100, "status": "active"},
+        {"id": 2, "value": -5, "status": "active"},
+        {"id": 3, "value": 200, "status": "inactive"},
+    ]
+
+
+@checkpoint
+def validate(records: list[dict]) -> dict:
+    """Simulate validating ingested records."""
+    log(step="validate", record_count=len(records))
+    time.sleep(1)
+    issues = [r for r in records if r["value"] < 0]
+    return {
+        "valid_count": len(records) - len(issues),
+        "issue_count": len(issues),
+        "issues": issues,
+        "records": records,
+    }
+
+
+@checkpoint
+def transform(validation: dict) -> list[dict]:
+    """Simulate transforming validated data."""
+    log(step="transform", valid_count=validation["valid_count"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated schema mismatch during transformation")
+    # --- end crash ---
+    time.sleep(2)
+    transformed = []
+    for r in validation["records"]:
+        if r["value"] >= 0:
+            transformed.append({
+                "id": r["id"],
+                "value_normalized": r["value"] / 100.0,
+                "is_active": r["status"] == "active",
+            })
+    return transformed
+
+
+@checkpoint
+def load_data(records: list[dict]) -> str:
+    """Simulate loading transformed data into a destination."""
+    log(step="load", record_count=len(records))
+    time.sleep(1)
+    return f"Loaded {len(records)} records into warehouse"
+
+
+@flow
+def data_flow(source: str) -> str:
+    """Ingest, validate, transform, approve, and load data."""
+    previous_source = memory.get("last_source")
+    if previous_source:
+        log(returning_user=True, previous_source=previous_source)
+
+    raw = ingest(source)
+    validation = validate(raw)
+
+    if validation["issue_count"] > 0:
+        log(data_quality_warning=True, issues=validation["issues"])
+
+    transformed = transform(validation)
+
+    approved = wait(
+        name="approve_load",
+        question=f"Approve loading {len(transformed)} records? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return "Data load was rejected"
+
+    result = load_data(transformed)
+    memory.set("last_source", source)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    source = sys.argv[1] if len(sys.argv) > 1 else "sales_data_2026_q1.csv"
+    handle = data_flow.run(source)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/research.py
+++ b/skills/kitaru-quickstart/references/tracks/research.py
@@ -1,0 +1,77 @@
+"""Research/content approval flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: gather sources → draft content → approve → publish
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def gather_sources(topic: str) -> list[str]:
+    """Simulate gathering research sources."""
+    log(step="gather", topic=topic)
+    time.sleep(1)
+    return [
+        f"Academic paper on {topic}",
+        f"Industry report: {topic} trends 2026",
+        f"Expert interview transcript about {topic}",
+    ]
+
+
+@checkpoint
+def draft_content(topic: str, sources: list[str]) -> str:
+    """Draft content from gathered sources."""
+    log(step="draft", source_count=len(sources))
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated network timeout during content generation")
+    # --- end crash ---
+    time.sleep(2)
+    lines = [f"# {topic}", "", "## Key Findings", ""]
+    lines.extend(f"- Finding from: {s}" for s in sources)
+    return "\n".join(lines)
+
+
+@checkpoint
+def publish(draft: str) -> str:
+    """Simulate publishing the approved content."""
+    log(step="publish", draft_length=len(draft))
+    time.sleep(1)
+    return f"Published at https://example.com/articles/{abs(hash(draft)) % 10000}"
+
+
+@flow
+def research_flow(topic: str) -> str:
+    """Research, draft, approve, and publish content about a topic."""
+    previous_topic = memory.get("last_topic")
+    if previous_topic:
+        log(returning_user=True, previous_topic=previous_topic)
+
+    sources = gather_sources(topic)
+    draft = draft_content(topic, sources)
+
+    approved = wait(
+        name="approve_draft",
+        question=f"Approve draft about '{topic}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Draft about '{topic}' was rejected"
+
+    result = publish(draft)
+    memory.set("last_topic", topic)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    topic = sys.argv[1] if len(sys.argv) > 1 else "durable AI agents"
+    handle = research_flow.run(topic)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")

--- a/skills/kitaru-quickstart/references/tracks/support.py
+++ b/skills/kitaru-quickstart/references/tracks/support.py
@@ -1,0 +1,82 @@
+"""Support/triage flow — Kitaru quickstart demo.
+
+Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Flow shape: classify ticket → draft response → approve → escalate
+"""
+
+import time
+
+from kitaru import checkpoint, flow, log, memory, wait
+
+
+@checkpoint
+def classify_ticket(ticket: str) -> dict:
+    """Simulate classifying an incoming support ticket."""
+    log(step="classify", ticket=ticket)
+    time.sleep(1)
+    return {
+        "ticket": ticket,
+        "category": "billing",
+        "priority": "high",
+        "sentiment": "frustrated",
+    }
+
+
+@checkpoint
+def draft_response(classification: dict) -> str:
+    """Simulate drafting a response to the classified ticket."""
+    log(step="draft_response", category=classification["category"])
+    # --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+    raise Exception("Simulated timeout calling response generation model")
+    # --- end crash ---
+    time.sleep(2)
+    return (
+        f"Dear customer,\n\n"
+        f"Thank you for reaching out about your {classification['category']} issue. "
+        f"We understand this is urgent (priority: {classification['priority']}). "
+        f"We're looking into this and will follow up within 24 hours.\n\n"
+        f"Best regards,\nSupport Team"
+    )
+
+
+@checkpoint
+def escalate(ticket: str, response: str) -> str:
+    """Simulate escalating the ticket with the approved response."""
+    log(step="escalate", ticket=ticket, response_length=len(response))
+    time.sleep(1)
+    return f"Ticket escalated to senior support. Response sent ({len(response)} chars)"
+
+
+@flow
+def support_flow(ticket: str) -> str:
+    """Classify a ticket, draft a response, approve, and escalate."""
+    previous_ticket = memory.get("last_ticket")
+    if previous_ticket:
+        log(returning_user=True, previous_ticket=previous_ticket)
+
+    classification = classify_ticket(ticket)
+    response = draft_response(classification)
+
+    approved = wait(
+        name="approve_escalation",
+        question=f"Approve escalation for '{ticket}'? (true/false)",
+        schema=bool,
+    )
+
+    if not approved:
+        return f"Escalation for '{ticket}' was rejected"
+
+    result = escalate(ticket, response)
+    memory.set("last_ticket", ticket)
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+
+    ticket = sys.argv[1] if len(sys.argv) > 1 else "billing charge incorrect on invoice #1234"
+    handle = support_flow.run(ticket)
+    print(f"Execution ID: {handle.exec_id}")
+    print(f"Status: {handle.status}")
+    result = handle.wait()
+    print(f"Result: {result}")


### PR DESCRIPTION
## Summary

- Adds `/kitaru-quickstart` — an interactive onboarding skill that scaffolds a personalized Kitaru demo, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory across executions, and optional MCP integration
- Four domain track templates (research/content, coding agent, data pipeline, support/triage) as tested Python reference files
- Five host adapter reference files (Claude Code, Cursor, Codex, Copilot, Gemini) + fallback MCP config guide
- Three depth levels: five-minute tour (crash→replay only), guided build (full walkthrough), guided build + MCP
- Updated README, AGENTS.md, CLAUDE.md, and bumped plugin version to 0.4.0
- Updated issue #2 with CLI corrections (`kitaru executions replay` not `kitaru replay`, no `kitaru ui` command)

### Key design decisions

- **Memory is woven into templates** (`memory.set`/`memory.get` in flow bodies) AND gets a dedicated Phase 2.5 demo showing cross-execution persistence
- **Pre-baked crash markers** (`# --- QUICKSTART CRASH ---`) in templates for deterministic failure injection — agent just removes marked lines rather than figuring out where to inject exceptions
- **Host MCP config** is only auto-configured for Claude Code and Cursor (authoritatively documented); Codex/Copilot/Gemini get honest "manual setup" guidance
- **All CLI commands verified against Kitaru source** via RepoPrompt context builder — no hallucinated APIs

### New files
```
skills/kitaru-quickstart/
├── SKILL.md
└── references/
    ├── tracks/
    │   ├── research.py, coding.py, data.py, support.py
    ├── hosts/
    │   ├── claude-code.md, cursor.md, codex.md, copilot.md, gemini.md
    └── mcp-config-guide.md
```

## Test plan

- [ ] Verify all 4 Python templates pass syntax check (`python -c "import ast; ast.parse(...)"`)
- [ ] Verify SKILL.md frontmatter triggers match expected keywords
- [ ] Verify CLI commands in SKILL.md match real Kitaru API surface
- [ ] Verify README skill table and workflow are consistent
- [ ] Verify plugin.json is valid JSON with version 0.4.0
- [ ] Manual smoke test: invoke `/kitaru-quickstart` in Claude Code and run through five-minute tour
- [ ] CI smoke tests are a follow-up issue (not in this PR)

Closes #2