### PR TITLE
Update quickstart tutorial flow

### DIFF
--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -10,7 +10,7 @@ description: >
   kitaru.wait, kitaru.log, kitaru.save, kitaru.load, kitaru.memory,
   memory.configure, memory.get, memory.set, memory.list, memory.history,
   memory.delete, KitaruClient, KitaruClient.memories, replay, resume, retry,
-  `kitaru run`, `kitaru executions ...`, `kitaru memory ...`, MCP tools,
+  `kitaru executions ...`, `kitaru memory ...`, MCP tools,
   `kitaru_memory_*`, `wrap(...)`, or `hitl_tool(...)`.
 ---
 
@@ -168,8 +168,10 @@ Key behavior to teach correctly:
 
 - Valid in the flow body
 - Invalid inside checkpoints
-- Inside a flow, the default scope is the flow name unless you configured a
-  different active scope
+- Inside a flow, the default scope is the active flow identity unless you
+  configured a different active scope. Operator surfaces may expose that flow
+  identity as a flow ID, so use execution details or `memory scopes` to find
+  the exact external scope value.
 - Outside a flow, configure an active scope first; `memory.configure(scope=...)`
   defaults to `scope_type="namespace"`
 - `memory.configure(scope_type="namespace")` still requires an explicit
@@ -381,7 +383,7 @@ memory/artifact administration**, not for launching new executions.
 
 | Capability | SDK | KitaruClient | CLI | MCP |
 |---|---|---|---|---|
-| Launch new execution | Yes (flow object) | No | Yes (`kitaru run`) | Yes (`kitaru_executions_run`) |
+| Launch new execution | Yes (flow object / Python entrypoint) | No | No top-level run command | Yes (`kitaru_executions_run`) |
 | Inspect execution | Limited (FlowHandle) | Yes | Yes | Yes |
 | Resolve wait input | No | Yes | Yes | Yes |
 | Abort wait | No | Yes (`abort_wait`) | No | No |

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -13,7 +13,7 @@ description: >
 
 Build and run a working Kitaru demo tailored to the user's domain. Take
 someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
-wait, and memory" in a single session.
+wait, memory, and the dashboard" in a single teaching session.
 
 > **Relationship to other skills**:
 > - `/kitaru-quickstart` → activation and intuition (this skill)
@@ -72,36 +72,102 @@ then offer `/kitaru-authoring` for PydanticAI conversion.
 | Guided build       | 0 → 1 → 2 → 2.5 → 3 → 5 |
 | Guided build + MCP | 0 → 1 → 2 → 2.5 → 3 → 4 → 5 |
 
+## Tutorial pacing rules
+
+This is a tutorial, not a firehose. Throughout the session:
+
+1. **After writing any non-trivial file**, stop and direct the user to open
+   it. Give concrete line numbers from the file you just wrote, point out
+   what to notice, and ask whether they want a walkthrough before you run it.
+2. **After every phase**, summarize what happened in plain language, explain
+   why it matters, and ask whether to continue or dig deeper.
+3. **Prefer dashboard-first teaching**. The CLI is the scriptable surface;
+   the dashboard is the visual "what just happened?" surface.
+4. **Use venv-aware commands** from inside the demo project:
+   `uv run kitaru ...`, `uv run python demo_flow.py`, and
+   `uv run kitaru-mcp ...`.
+5. Refer to the demo directory as `<DEMO_DIR>` and its absolute path as
+   `<ABSOLUTE_DEMO_DIR>`. Capture the absolute path with `pwd` after
+   creating the project.
+
 ---
 
-## Phase 0: Environment setup
+## Phase 0: Environment setup and dashboard
 
-1. **Check safety**: Is the current directory safe to modify?
-   - If it has `src/`, `.git` with uncommitted changes, `package.json`,
-     `pyproject.toml`, or other project markers: ask the user and default to
-     creating `./kitaru-quickstart-demo/`.
-   - If it is empty or a scratch directory: work here.
+1. **Check safety and avoid ancestor uv config traps**:
+   - If the current directory has `src/`, `.git`, `package.json`,
+     `pyproject.toml`, `uv.toml`, or other project markers, do not scaffold
+     inside it by default.
+   - `uv` can inherit ancestor `[tool.uv] exclude-newer = ...` settings and
+     silently hide recent Kitaru releases. To avoid that trap, default to a
+     neutral location such as `$HOME/kitaru-quickstart-demo` or `/tmp`.
+   - If the user insists on a custom path, check for ancestor uv config first
+     and explain the risk before proceeding.
 
-2. **Verify Python**: `python3 --version` (require 3.10+)
-
-3. **Verify uv**: `uv --version`
-   - If missing, suggest:
-     `curl -LsSf https://astral.sh/uv/install.sh | sh`
-
-4. **Create project and install Kitaru**:
+2. **Verify prerequisites**:
    ```bash
-   mkdir -p kitaru-quickstart-demo
-   cd kitaru-quickstart-demo
-   uv init --no-workspace
-   uv add kitaru
+   python3 --version
+   uv --version
+   ```
+   Require Python 3.10+. If `uv` is missing, suggest:
+   `curl -LsSf https://astral.sh/uv/install.sh | sh`
+
+3. **Choose the demo project directory before creating anything**:
+   ```bash
+   cd "$HOME"
+   if [ -e kitaru-quickstart-demo ]; then
+     echo "kitaru-quickstart-demo already exists"
+   fi
    ```
 
-5. **Initialize Kitaru**: `kitaru init`
+   If the directory already exists, ask whether to reuse it, create a suffixed
+   directory such as `kitaru-quickstart-demo-2`, or delete/recreate it after
+   explicit approval. Do not run `uv init` until the user has made that choice.
 
-6. **Verify**: `kitaru status`
+   Then create the approved directory and install Kitaru:
 
-If any step fails, explain the error, apply a fix, and retry once. If it
-fails again, present the error to the user and ask for guidance.
+   ```bash
+   DEMO_DIR="kitaru-quickstart-demo"  # or the approved suffixed name
+   mkdir -p "$DEMO_DIR"
+   cd "$DEMO_DIR"
+   pwd
+   uv init --no-workspace
+   uv add 'kitaru[local,mcp]>=0.4.0'
+   ```
+
+   Store the printed `pwd` value as `<ABSOLUTE_DEMO_DIR>`.
+
+   If `uv add` says only an older Kitaru version is available, explain that
+   an ancestor `exclude-newer` setting may be filtering PyPI. Move the demo
+   to a neutral path and retry. If it still fails, stop with the clear
+   message that this quickstart needs Kitaru `>=0.4.0` because it uses
+   module-level `kitaru.memory`.
+
+4. **Initialize and verify Kitaru**:
+   ```bash
+   uv run kitaru --version
+   uv run kitaru init
+   uv run kitaru status
+   ```
+
+5. **Start the local server and open the dashboard**:
+   ```bash
+   uv run kitaru login
+   ```
+
+   Tell the user:
+
+   > "Kitaru's local server should now be running. Open
+   > http://127.0.0.1:8383 in your browser. Take a minute to look around —
+   > the dashboard is where you'll be able to see executions, checkpoints,
+   > waits, and replay behavior visually. Tell me when you've had a look and
+   > we'll continue."
+
+   Pause here and wait for acknowledgement. If local server startup fails
+   because local dependencies are missing, rerun
+   `uv add 'kitaru[local,mcp]>=0.4.0'` and retry once. If the dashboard is
+   unavailable but `uv run kitaru status` works, ask whether to continue with
+   CLI-only inspection.
 
 ---
 
@@ -114,23 +180,23 @@ This is the core activation sequence. It must feel dramatic, not academic.
 Read the template from `references/tracks/{track}.py` based on the user's
 domain choice:
 
-| Domain          | Template file  | Flow name        |
-|-----------------|---------------|------------------|
-| Research/content| `research.py` | `research_flow`  |
-| Coding agent    | `coding.py`   | `coding_flow`    |
-| Data pipeline   | `data.py`     | `data_flow`      |
-| Support/triage  | `support.py`  | `support_flow`   |
+| Domain           | Template file  | Flow name       | Replay from      |
+|------------------|----------------|-----------------|------------------|
+| Research/content | `research.py`  | `research_flow` | `draft_content`  |
+| Coding agent     | `coding.py`    | `coding_flow`   | `generate_patch` |
+| Data pipeline    | `data.py`      | `data_flow`     | `transform`      |
+| Support/triage   | `support.py`   | `support_flow`  | `draft_response` |
 
 ### Step 2: Customize the template
 
 Adapt variable names, mock data, and print statements to the user's domain.
 
 **CRITICAL**: Do NOT alter the placement, arguments, or syntax of `@flow`,
-`@checkpoint`, `wait()`, `log()`, or `memory.*` calls. Only customize the
-internal business logic of checkpoint functions (string content, mock data
-values, variable names).
+`@checkpoint`, `wait()`, `log()`, `memory.*`, or the `--replay` helper. Only
+customize the internal business logic of checkpoint functions: string
+content, mock data values, and explanatory print text.
 
-### Step 3: Write the customized flow
+### Step 3: Write and inspect the customized flow
 
 Write the customized template to `demo_flow.py` in the project directory.
 The template includes a pre-baked crash marked with:
@@ -141,116 +207,186 @@ raise Exception("Simulated ...")
 # --- end crash ---
 ```
 
-### Step 4: Run the flow (it will crash)
+After writing the file, show line numbers:
+
+```bash
+nl -ba demo_flow.py | sed -n '1,180p'
+```
+
+Pause and tell the user to open `demo_flow.py`. Point out exact line ranges
+for these items:
+
+- the `@flow` function: this is the durable orchestration boundary;
+- the `@checkpoint` functions: these are replay save points;
+- `memory.get(...)` and `memory.set(...)`: these deliberately live in the
+  flow body, not inside checkpoints;
+- the simulated crash in the second meaningful checkpoint;
+- the `wait(...)` gate that will pause for human input later;
+- the `--replay <EXEC_ID>` helper at the bottom of the file.
+
+Ask: "Want me to walk through any part of this before we run it?" Wait for
+acknowledgement before proceeding.
+
+### Step 4: Run the flow — it should crash
 
 ```bash
 uv run python demo_flow.py
 ```
 
-Read the output. Verify you see a traceback at the second checkpoint.
+Read the output. Verify you see a traceback at the simulated crash in the
+second checkpoint. Then ask the user to look at the dashboard: the failed
+execution should now be visible in the runs list.
 
 ### Step 5: Explain the crash
 
 Tell the user:
 
 > "The flow crashed at the second checkpoint. In a traditional script,
-> everything from checkpoint 1 would be lost — you'd rerun the entire
-> pipeline and redo all that work. With Kitaru, checkpoint 1's output is
-> saved to the local SQLite database. Let's fix the crash and replay from
-> exactly where it broke."
+> everything before that crash is just gone unless you built your own save
+> system. With Kitaru, checkpoint 1 is already persisted. Think of it like a
+> video game save point: we can fix the bug and resume from the save instead
+> of replaying the whole level."
 
 ### Step 6: Fix the code
 
-Remove the lines between `# --- QUICKSTART CRASH ---` and
-`# --- end crash ---` from `demo_flow.py`.
+Remove the crash marker block from `demo_flow.py`:
 
-### Step 7: Get the execution ID
+```python
+# --- QUICKSTART CRASH: remove this line to fix the simulated failure ---
+raise Exception("Simulated ...")
+# --- end crash ---
+```
+
+Show the diff or the relevant edited line range. Pause briefly and say what
+changed before replaying.
+
+### Step 7: Get the failed execution ID
 
 From the crash output, or run:
 
 ```bash
-kitaru executions list --output json
+uv run kitaru executions list --output json
 ```
 
 Extract the execution ID of the failed run.
 
 ### Step 8: Replay from the failed checkpoint
 
+Use the template's Python replay helper as the guided quickstart path:
+
 ```bash
-kitaru executions replay <EXEC_ID> --from <CHECKPOINT_NAME>
+uv run python demo_flow.py --replay <FAILED_EXEC_ID>
 ```
 
-Checkpoint names by track:
+If this command prints an execution ID and then appears to keep running, that
+is expected when the replay reaches the `wait()` gate. Leave that terminal
+open. In a second terminal, run `cd <ABSOLUTE_DEMO_DIR>` before using the
+input command. If the user chose the five-minute tour, resolve that wait now
+with `uv run kitaru executions input <EXEC_ID> --value true` so the replay can
+finish before handoff. If the user chose guided build, use the parked replay
+execution as the bridge into Phase 2 instead of starting another run.
 
-| Track           | Replay from       |
-|-----------------|-------------------|
-| Research/content| `draft_content`   |
-| Coding agent    | `generate_patch`  |
-| Data pipeline   | `transform`       |
-| Support/triage  | `draft_response`  |
+The helper calls `flow.replay(exec_id, from_="<CHECKPOINT_NAME>")` with the
+track's replay checkpoint. This avoids the known local CLI fallback issue
+where direct CLI replay can fail to resolve the flow object. If the helper is
+not available for some reason, the CLI workaround is:
 
-### Step 9: Verify and explain
+```bash
+PYTHONPATH=. uv run kitaru executions replay <FAILED_EXEC_ID> --from <CHECKPOINT_NAME>
+```
 
-Read the replay output. Verify that checkpoint 1 was loaded from cache (not
-re-executed). Then tell the user:
+### Step 9: Verify in the dashboard and explain
 
-> "Notice that the first checkpoint was loaded from cache and skipped —
-> only the second checkpoint onwards re-executed. That's crash recovery
-> with zero wasted work. In production, this means no burned tokens, no
-> repeated API calls, no lost progress."
+Read the replay output, then ask the user to inspect the dashboard. They
+should be able to compare the failed source execution with the replayed
+execution and see that earlier work was reused instead of repeated.
 
-**Verification**: If the output does not show caching behavior, read the
-full output, diagnose the issue, and retry once.
+Tell the user:
 
-If the user chose **five-minute tour**, skip to **Phase 5**.
+> "The important thing is not just that the code ran after the fix. The
+> important thing is where it restarted. Kitaru kept the completed checkpoint
+> and replayed from the named boundary. That's the durable-execution trick:
+> no burned tokens, no repeated API calls, no lost progress."
+
+**Verification**: If replay fails, read the full output. First retry with the
+`PYTHONPATH=.` CLI workaround above. If that also fails, stop and present the
+error instead of looping.
+
+End the phase with a plain-language recap and ask whether to continue. If
+the user chose **five-minute tour**, skip to **Phase 5**.
 
 ---
 
 ## Phase 2: Human-in-the-loop with `wait()`
 
-### Step 1: Run the flow again
+### Step 1: Explain before running
 
-The crash is now fixed. Run the flow:
+Before triggering the wait, tell the user:
+
+> "The next run will reach a `wait()` gate. That means the execution parks
+> safely and releases compute while it waits for input. The dashboard should
+> show it as waiting, and the CLI can provide the input later."
+
+### Step 2: Reach a waiting execution
+
+If the Phase 1 replay is already parked at `wait()`, reuse that execution for
+this phase. Do not start a second run just to demonstrate the same wait.
+
+If there is no waiting execution yet, run the flow again:
 
 ```bash
 uv run python demo_flow.py
 ```
 
-The flow will pause at the `wait()` gate.
-
-### Step 2: Explain the pause
-
-> "The flow is now paused at a wait gate. In production, your agent
-> releases compute while waiting — no idle containers burning money. The
-> execution state is safely persisted. A human (or another agent) can
-> provide input whenever they're ready."
+The flow should pause at the `wait()` gate. Because `demo_flow.py` waits for
+the final result, the terminal may stay occupied after it prints the execution
+ID. That is expected. Leave it open and use a second terminal in
+`<ABSOLUTE_DEMO_DIR>` to provide input. Show the user the waiting status in
+the dashboard before resolving it.
 
 ### Step 3: Provide input
 
+The quickstart templates have one pending wait at a time, so the CLI resolves
+the single pending wait by execution ID. Do **not** pass a `--wait` flag.
+
 ```bash
-kitaru executions input <EXEC_ID> --wait <WAIT_NAME> --value true
+uv run kitaru executions input <EXEC_ID> --value true
 ```
 
-Wait names by track:
+Wait names by track, useful for recognizing the dashboard entry:
 
-| Track           | Wait name            |
-|-----------------|----------------------|
-| Research/content| `approve_draft`      |
-| Coding agent    | `approve_merge`      |
-| Data pipeline   | `approve_load`       |
-| Support/triage  | `approve_escalation` |
+| Track            | Wait name             |
+|------------------|-----------------------|
+| Research/content | `approve_draft`       |
+| Coding agent     | `approve_merge`       |
+| Data pipeline    | `approve_load`        |
+| Support/triage   | `approve_escalation`  |
+
+If an execution has multiple pending waits, switch to:
+
+```bash
+uv run kitaru executions input --interactive
+```
 
 ### Step 4: Resume if needed
 
-If the execution does not auto-continue:
+Input normally continues the execution. If it does not auto-continue:
 
 ```bash
-kitaru executions resume <EXEC_ID>
+uv run kitaru executions resume <EXEC_ID>
 ```
 
-### Step 5: Verify completion
+### Step 5: Verify and summarize
 
-Confirm the flow completed successfully and show the final output.
+Confirm the flow completed successfully in both CLI output and the dashboard.
+Then summarize:
+
+> "The execution was paused without losing state. We gave it a value later,
+> and it continued from the wait gate rather than starting over. This is how
+> long-running agent workflows can include human approval without babysitting
+> a live process."
+
+Ask whether the user wants to continue to memory or discuss waits first.
 
 ---
 
@@ -258,83 +394,123 @@ Confirm the flow completed successfully and show the final output.
 
 ### Step 1: Explain memory
 
-> "Kitaru has durable memory — your flows can remember state across
-> executions. The flow you just ran stored some context. Let's run it
-> again with different input and watch it remember."
+> "Kitaru memory lets a flow remember small pieces of state across
+> executions. In this demo, the flow records the last topic/issue/source/ticket
+> after approval, then reads it at the start of the next run."
 
 ### Step 2: Run the flow again with different input
 
 Choose a different argument that makes sense for the track:
 
-| Track           | Example second input             |
-|-----------------|----------------------------------|
-| Research/content| `"quantum computing"`            |
-| Coding agent    | `"optimize database query speed"`|
-| Data pipeline   | `"inventory_data_2026_q2.csv"`   |
-| Support/triage  | `"login page returns 500 error"` |
+| Track            | Example second input              |
+|------------------|-----------------------------------|
+| Research/content | `"quantum computing"`             |
+| Coding agent     | `"optimize database query speed"` |
+| Data pipeline    | `"inventory_data_2026_q2.csv"`    |
+| Support/triage   | `"login page returns 500 error"`  |
 
 ```bash
 uv run python demo_flow.py "<new input>"
 ```
 
-### Step 3: Point out the memory detection
+If the dashboard or log backend shows the early
+`log(returning_user=True, ...)` metadata, point it out. If logs are sparse,
+do not treat that as a failure — the durable proof comes from the CLI memory
+inspection in the next steps. If the run pauses at `wait()`, resolve it with
+the Phase 2 command so the final `memory.set(...)` call can write the new
+value.
 
-The flow logs should show it detected the previous input from memory. Point
-this out to the user.
+### Step 3: Find the flow UUID for CLI memory inspection
+
+Inside the flow body, module-level `kitaru.memory` resolves the active flow
+scope automatically. Outside the flow, CLI/MCP/Client calls need an explicit
+typed scope. For this quickstart, use the **flow UUID**, not the Python
+function name.
+
+Get the execution details:
+
+```bash
+uv run kitaru executions get <EXEC_ID> --output json
+```
+
+Extract `item.flow_id` from the JSON. If that is not obvious, run:
+
+```bash
+uv run kitaru memory scopes --output json
+```
+
+and choose the row where `scope_type` is `flow` and the scope corresponds to
+the demo flow. Do not use `research_flow`, `coding_flow`, `data_flow`, or
+`support_flow` as the CLI scope unless the current CLI explicitly reports
+that exact value as the scope.
 
 ### Step 4: Inspect memory from the CLI
 
-The templates use module-level `kitaru.memory` inside the flow body, so the
-values live in the default flow typed scope. CLI inspection needs both the
-scope value and the scope type:
-
 ```bash
-kitaru memory list --scope <FLOW_NAME> --scope-type flow
-kitaru memory get <MEMORY_KEY> --scope <FLOW_NAME> --scope-type flow
+uv run kitaru memory list --scope <FLOW_ID> --scope-type flow
+uv run kitaru memory get <MEMORY_KEY> --scope <FLOW_ID> --scope-type flow
 ```
 
 Memory scope and key names by track:
 
-| Track            | Scope type | Scope value     | Memory key    |
-|------------------|------------|-----------------|---------------|
-| Research/content | `flow`     | `research_flow` | `last_topic`  |
-| Coding agent     | `flow`     | `coding_flow`   | `last_issue`  |
-| Data pipeline    | `flow`     | `data_flow`     | `last_source` |
-| Support/triage   | `flow`     | `support_flow`  | `last_ticket` |
+| Track            | Flow function in code | Scope type | CLI scope value                  | Memory key    |
+|------------------|-----------------------|------------|----------------------------------|---------------|
+| Research/content | `research_flow`       | `flow`     | `flow_id` from execution details | `last_topic`  |
+| Coding agent     | `coding_flow`         | `flow`     | `flow_id` from execution details | `last_issue`  |
+| Data pipeline    | `data_flow`           | `flow`     | `flow_id` from execution details | `last_source` |
+| Support/triage   | `support_flow`        | `flow`     | `flow_id` from execution details | `last_ticket` |
 
 ### Step 5: Explain
 
-> "Memory persists across executions under stable keys. Your agent can
-> accumulate knowledge, preferences, or context over time. Operators can
-> inspect or edit that state from the CLI, Python client, or MCP tools."
+> "The code had the easy experience: inside the flow, memory knew which flow
+> it belonged to. Operator tools need the explicit typed scope, so we used the
+> flow UUID. This is like the difference between saying 'my house' while
+> you're standing in it and giving someone the exact street address from
+> outside."
+
+Ask whether the user wants to continue to the CLI inspection tour.
 
 ---
 
 ## Phase 3: Inspect and explore
 
+Frame this phase as: "The dashboard showed this visually; the CLI gives you
+the same kind of state in scriptable form."
+
 ### Step 1: Show execution history
 
 ```bash
-kitaru executions list
+uv run kitaru executions list
 ```
 
 ### Step 2: Inspect a specific execution
 
 ```bash
-kitaru executions get <EXEC_ID>
+uv run kitaru executions get <EXEC_ID>
 ```
 
-### Step 3: View structured logs
+Use this as the reliable inspection surface for status, flow name/ID,
+checkpoint count, pending wait, and failure information.
+
+### Step 3: View logs with correct expectations
 
 ```bash
-kitaru executions logs <EXEC_ID>
+uv run kitaru executions logs <EXEC_ID>
 ```
+
+Do not promise that this always shows rich structured logs. On the default
+local stack, log output may be sparse or say "No log entries found" depending
+on the active log store and runtime setup. That is not a quickstart failure;
+fall back to `executions get` and the dashboard.
 
 ### Step 4: Explain
 
-> "Every checkpoint, wait, memory operation, and log call is tracked.
-> This gives you full observability into what your agent did, when, and
-> why — without building custom logging infrastructure."
+> "The dashboard is the visual way to understand what happened. The CLI is
+> the scriptable way to inspect the same executions, waits, checkpoints, and
+> failures. Logs are useful when the active log backend captures them, but
+> execution details are the dependable baseline."
+
+End with a short recap and ask before continuing.
 
 ---
 
@@ -344,9 +520,10 @@ Only run this phase if the user chose **guided build + MCP**.
 
 ### Step 1: Explain the value
 
-> "I can configure your environment so I can directly query Kitaru's
-> execution database, provide input to waiting flows, and trigger
-> replays — all through natural language."
+> "I can configure your agent host so it can query Kitaru's execution state,
+> provide input to waiting flows, and trigger replays through MCP. Because MCP
+> hosts often launch outside your activated shell, we will point the host at
+> the demo project's uv environment explicitly."
 
 ### Step 2: Detect the host
 
@@ -356,13 +533,20 @@ Check filesystem markers:
 - `.cursor/` or `.cursorignore` → Cursor
 - `.codex/` → Codex CLI
 
-If no markers found or multiple matches, ask the user which host they are
-using.
+If no markers are found or multiple match, ask which host the user is using.
 
-### Step 3: Install the MCP extra
+### Step 3: Verify the MCP extra and server command
+
+Phase 0 installs the MCP extra. If that was skipped or changed, run:
 
 ```bash
-uv add kitaru --extra mcp
+uv add 'kitaru[local,mcp]>=0.4.0'
+```
+
+Then verify through the project environment:
+
+```bash
+uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp --help
 ```
 
 ### Step 4: Load the host-specific guide
@@ -374,6 +558,23 @@ Read the appropriate file from `references/hosts/{host}.md`:
 - Codex → `references/hosts/codex.md`
 - Copilot → `references/hosts/copilot.md`
 - Gemini → `references/hosts/gemini.md`
+
+The server configuration should use this shape unless the host requires a
+different wrapper:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]
+    }
+  }
+}
+```
+
+Do not configure this quickstart with a bare `kitaru-mcp` command unless the
+user has installed Kitaru globally and explicitly asks for that form.
 
 ### Step 5: Ask for explicit consent
 
@@ -387,7 +588,8 @@ Before modifying any configuration file:
 
 ### Step 6: Apply configuration
 
-Follow the host-specific guide to configure the MCP server.
+Follow the host-specific guide to configure the MCP server. Merge into
+existing JSON instead of overwriting other servers.
 
 ### Step 7: Demonstrate MCP tools
 
@@ -395,7 +597,7 @@ Show at least 3 MCP tools in action against the demo flow:
 
 1. **List executions** — show the executions from earlier phases
 2. **Inspect execution** — read status and details of a specific run
-3. **Read logs** — show structured logs from a checkpoint
+3. **Read logs if available** — explain sparse logs the same way as Phase 3
 
 If a wait is currently pending, also demonstrate:
 4. **Provide input** — resolve a wait via MCP
@@ -403,30 +605,47 @@ If a wait is currently pending, also demonstrate:
 If applicable:
 5. **Replay** — trigger a replay via MCP
 
+For MCP memory tools, remind the user that scoped memory calls require both
+`scope_type` and `scope`. For this quickstart, use `scope_type="flow"` and the
+flow UUID discovered in Phase 2.5.
+
 ### Step 8: Handle failure
 
 If MCP installation or configuration fails:
 
-1. Read `references/mcp-config-guide.md`
-2. Explain the manual setup path to the user
-3. Continue to Phase 5 without MCP
+1. Read `references/mcp-config-guide.md`.
+2. Explain the manual setup path to the user.
+3. Continue to Phase 5 without MCP.
 
 ---
 
-## Phase 5: Handoff and next steps
+## Phase 5: Handoff, next steps, and teardown
 
 ### Step 1: Write `KITARU_NEXT_STEPS.md`
 
 Write this file to the project directory, filling in the actual values from
 the session:
 
-```markdown
+````markdown
 # Kitaru Quickstart — What You Built
 
 ## Demo summary
 - **Domain**: [user's chosen domain]
 - **Flow**: [flow name] with [N] checkpoints
+- **Demo directory**: [absolute path]
+- **Dashboard**: http://127.0.0.1:8383
 - **Demonstrated**: crash recovery, replay[, wait(), memory, MCP]
+
+## Commands worth remembering
+
+```bash
+uv run kitaru status
+uv run kitaru executions list
+uv run kitaru executions get <EXEC_ID>
+uv run python demo_flow.py --replay <FAILED_EXEC_ID>
+uv run kitaru executions input <EXEC_ID> --value true
+uv run kitaru memory list --scope <FLOW_ID> --scope-type flow
+```
 
 ## Kitaru primitives used
 
@@ -435,9 +654,19 @@ the session:
 | `@flow` | Durable orchestration boundary | `demo_flow.py` |
 | `@checkpoint` | Replay-safe unit of work | `demo_flow.py` |
 | `wait()` | Human-in-the-loop gate | `demo_flow.py` |
-| `log()` | Structured metadata | `demo_flow.py` |
+| `log()` | Structured metadata when supported by the log backend | `demo_flow.py` |
 | `memory.set/get` | Cross-execution durable state | `demo_flow.py` |
-| `replay` | Re-execute from a checkpoint | CLI |
+| `replay` | Re-execute from a checkpoint boundary | `demo_flow.py --replay` |
+
+## Cleanup options
+
+- Keep the demo directory if you want to experiment more.
+- Stop the local server / disconnect when finished:
+  `uv run kitaru logout`
+- Preview project cleanup from inside the demo directory:
+  `uv run kitaru clean project --dry-run`
+- Delete the demo directory only after confirming the exact path:
+  `rm -rf [absolute path]`
 
 ## Next steps
 - **`/kitaru-scoping`** — Design durability for a real workflow
@@ -447,10 +676,14 @@ the session:
 - [Kitaru documentation](https://kitaru.ai/docs)
 - [ZenML Slack](https://zenml.io/slack)
 - [Kitaru SDK repository](https://github.com/zenml-io/kitaru)
-```
+````
 
 Adjust the "Demonstrated" line and primitives table based on which phases
-actually ran (five-minute tour only shows crash recovery and replay).
+actually ran. Five-minute tour only shows dashboard setup, crash recovery,
+and replay.
+
+After writing the file, pause and tell the user to open it. Ask whether the
+summary matches what they learned.
 
 ### Step 2: Offer next steps
 
@@ -461,6 +694,21 @@ actually ran (five-minute tour only shows crash recovery and replay).
 > - **`/kitaru-authoring`** if you have existing code you'd like to
 >   refactor with Kitaru primitives
 
+### Step 3: Offer cleanup, defaulting to keep
+
+Ask whether the user wants to keep or remove the demo. Default to keeping it.
+If they want cleanup:
+
+1. If the local server is running, suggest `uv run kitaru logout`.
+2. If MCP config was added, offer to remove only the `kitaru` MCP entry.
+   Show the exact diff and require approval.
+3. If they want to delete the demo directory, show `<ABSOLUTE_DEMO_DIR>` and
+   ask for explicit approval before running `rm -rf <ABSOLUTE_DEMO_DIR>`.
+4. If they want to reset Kitaru state instead of deleting files, start with
+   `uv run kitaru clean project --dry-run` and explain what would be removed.
+
+Never silently delete the demo directory or modify global MCP configuration.
+
 ---
 
 ## Guardrails
@@ -469,38 +717,56 @@ Enforce these rules throughout the entire session:
 
 1. **Template integrity**: Never alter the placement, arguments, or syntax
    of `@flow`, `@checkpoint`, `wait()`, `log()`, `memory.*`, `save()`, or
-   `load()` decorators or calls. Only customize the internal business
-   logic of checkpoint functions.
+   `load()` decorators or calls. Only customize internal business logic and
+   explanatory text. Preserve the template's `--replay` helper.
 
 2. **Scope limit**: Keep generated code under 150 lines. Use mock functions
    with `time.sleep()` to simulate latency. Do not implement real API
    connections or complex data processing.
 
-3. **Verification**: After every terminal command, read the output and
+3. **Tutorial pacing**: After writing code, stop for inspection. After each
+   phase, summarize and ask whether to continue.
+
+4. **Verification**: After every terminal command, read the output and
    verify success before proceeding. Never assume a command worked.
 
-4. **Failure recovery**: If a step fails, explain the error, apply a fix,
-   and retry once. If it fails again, present the error to the user and
-   ask for guidance. Do not loop.
+5. **Failure recovery**: If a step fails, explain the error, apply a fix,
+   and retry once. If it fails again, present the error to the user and ask
+   for guidance. Do not loop.
 
-5. **MCP consent**: Never write to MCP config files without showing the
-   user the exact diff and receiving explicit approval.
+6. **MCP consent**: Never write to MCP config files without showing the user
+   the exact diff and receiving explicit approval.
 
-6. **No blanket shell approval**: Do not request broad shell preapproval
-   from the user.
+7. **No blanket shell approval**: Do not request broad shell preapproval from
+   the user.
 
-7. **Memory placement**: `memory.*` calls belong in the flow body only,
-   never inside checkpoints.
+8. **Memory placement**: `memory.*` calls belong in the flow body only,
+   never inside checkpoints. CLI/MCP memory inspection needs explicit typed
+   scopes; for this quickstart's flow memory, use `scope_type=flow` and the
+   `flow_id`, not the Python function name.
 
-8. **Real commands only**: Use only documented Kitaru CLI commands:
-   - Replay: `kitaru executions replay <id> --from <checkpoint>`
-     (not `kitaru replay`)
-   - There is no `kitaru ui` command
-   - There is no top-level `kitaru run` command
-   - Wait input: `kitaru executions input <id> --wait <name> --value <val>`
+9. **Real commands only**: Use only documented Kitaru CLI commands and this
+   quickstart's validated forms:
+   - Install: `uv add 'kitaru[local,mcp]>=0.4.0'`
+   - Local server/dashboard: `uv run kitaru login`, then open
+     `http://127.0.0.1:8383`
+   - Guided replay: `uv run python demo_flow.py --replay <id>`
+   - CLI replay workaround: `PYTHONPATH=. uv run kitaru executions replay <id> --from <checkpoint>`
+   - Wait input: `uv run kitaru executions input <id> --value <json>`
+   - There is no `kitaru ui`, `kitaru dashboard`, or top-level `kitaru run`
+     command in this quickstart.
 
-9. **No API key requirements**: The quickstart must run without any API
-   keys, cloud credentials, or external service accounts.
+10. **Logs expectations**: Do not promise that `kitaru executions logs` always
+    returns rich structured logs. Empty or sparse logs on the default local
+    setup are acceptable; use `executions get` and the dashboard as the
+    reliable baseline.
 
-10. **Checkpoint outputs must be serializable**: All mock return values from
-    checkpoints must be JSON-serializable (strings, numbers, lists, dicts).
+11. **MCP command shape**: Do not configure MCP with a bare `kitaru-mcp` in
+    this quickstart. Use `command: "uv"` with
+    `args: ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]`.
+
+12. **No API key requirements**: The quickstart must run without API keys,
+    cloud credentials, or external service accounts.
+
+13. **Checkpoint outputs must be serializable**: All mock return values from
+    checkpoints must be JSON-serializable: strings, numbers, lists, and dicts.

--- a/skills/kitaru-quickstart/references/hosts/claude-code.md
+++ b/skills/kitaru-quickstart/references/hosts/claude-code.md
@@ -5,14 +5,17 @@
 - `.claude/` directory exists
 - `.claude/settings.json` exists
 
-## Option A: CLI registration (recommended)
+## Option A: CLI registration
+
+Use the demo project's uv environment instead of a bare `kitaru-mcp` binary:
 
 ```bash
-claude mcp add kitaru kitaru-mcp
+claude mcp add kitaru uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp
 ```
 
-This registers the Kitaru MCP server in Claude Code's project-scoped
-configuration. No file edits needed.
+If your Claude Code version rejects command arguments in this form, use
+Option B instead. The important part is the server argv:
+`uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp`.
 
 ## Option B: Project `.mcp.json` file
 
@@ -22,7 +25,8 @@ Create or merge into `.mcp.json` at the project root:
 {
   "mcpServers": {
     "kitaru": {
-      "command": "kitaru-mcp"
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]
     }
   }
 }
@@ -33,7 +37,8 @@ If `.mcp.json` already exists, merge the `kitaru` key into the existing
 
 ## After setup
 
-Claude Code picks up MCP changes on the next message. No restart is needed.
+Claude Code picks up MCP changes on the next message. No restart is usually
+needed.
 
 ## Scopes
 
@@ -43,4 +48,4 @@ Claude Code supports three configuration scopes:
 - **User** (`~/.claude/settings.json`)
 - **Organization** (managed by team admin)
 
-The CLI `claude mcp add` command defaults to project scope.
+The CLI `claude mcp add` command normally defaults to project scope.

--- a/skills/kitaru-quickstart/references/hosts/codex.md
+++ b/skills/kitaru-quickstart/references/hosts/codex.md
@@ -6,15 +6,16 @@
 
 ## Configuration
 
-Codex CLI MCP configuration is not yet authoritatively documented in the
-Kitaru repository. The Kitaru MCP server executable is:
+Codex CLI MCP configuration may vary by installation. The Kitaru MCP server
+should still be launched through the demo project's uv environment:
 
-```
-kitaru-mcp
+```bash
+uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp
 ```
 
 Suggest the user consult the Codex CLI documentation for the correct MCP
-configuration path and format, then use `kitaru-mcp` as the server command.
+configuration path and format, then use the command/args form below rather
+than a bare `kitaru-mcp` executable.
 
 If the user knows their Codex MCP config location, the general pattern is:
 
@@ -22,7 +23,8 @@ If the user knows their Codex MCP config location, the general pattern is:
 {
   "mcpServers": {
     "kitaru": {
-      "command": "kitaru-mcp"
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]
     }
   }
 }

--- a/skills/kitaru-quickstart/references/hosts/copilot.md
+++ b/skills/kitaru-quickstart/references/hosts/copilot.md
@@ -7,15 +7,27 @@ host if Copilot is suspected.
 
 ## Configuration
 
-GitHub Copilot MCP configuration is not yet authoritatively documented in
-the Kitaru repository. The Kitaru MCP server executable is:
+GitHub Copilot MCP configuration may vary by editor/version. The Kitaru MCP
+server should still be launched through the demo project's uv environment:
 
-```
-kitaru-mcp
+```bash
+uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp
 ```
 
 Suggest the user consult GitHub Copilot documentation for MCP server
-registration, then use `kitaru-mcp` as the server command.
+registration, then use this command/args shape rather than a bare
+`kitaru-mcp` executable:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]
+    }
+  }
+}
+```
 
 ## Fallback
 

--- a/skills/kitaru-quickstart/references/hosts/cursor.md
+++ b/skills/kitaru-quickstart/references/hosts/cursor.md
@@ -8,13 +8,15 @@
 
 ## Configuration
 
-Create or merge into `.cursor/mcp.json`:
+Create or merge into `.cursor/mcp.json`. Use the demo project's uv
+environment instead of a bare `kitaru-mcp` executable:
 
 ```json
 {
   "mcpServers": {
     "kitaru": {
-      "command": "kitaru-mcp",
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"],
       "transport": "stdio"
     }
   }

--- a/skills/kitaru-quickstart/references/hosts/gemini.md
+++ b/skills/kitaru-quickstart/references/hosts/gemini.md
@@ -7,15 +7,27 @@ their host if Gemini is suspected.
 
 ## Configuration
 
-Gemini CLI MCP configuration is not yet authoritatively documented in the
-Kitaru repository. The Kitaru MCP server executable is:
+Gemini CLI MCP configuration may vary by installation. The Kitaru MCP server
+should still be launched through the demo project's uv environment:
 
-```
-kitaru-mcp
+```bash
+uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp
 ```
 
 Suggest the user consult Gemini CLI documentation for MCP server
-registration, then use `kitaru-mcp` as the server command.
+registration, then use this command/args shape rather than a bare
+`kitaru-mcp` executable:
+
+```json
+{
+  "mcpServers": {
+    "kitaru": {
+      "command": "uv",
+      "args": ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]
+    }
+  }
+}
+```
 
 ## Fallback
 

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -5,31 +5,37 @@ is not directly supported.
 
 ## Install the MCP extra
 
+With uv:
+
 ```bash
-uv add kitaru --extra mcp
+uv add 'kitaru[mcp]>=0.4.0'
 ```
 
 Or with pip:
 
 ```bash
-pip install "kitaru[mcp]"
+pip install 'kitaru[mcp]>=0.4.0'
 ```
 
-## Verify installation
+## Verify installation from the project environment
+
+Prefer the uv directory form so the MCP host uses the same virtual
+environment where Kitaru was installed:
 
 ```bash
-kitaru-mcp --help
+uv run --directory <ABSOLUTE_PROJECT_PATH> kitaru-mcp --help
 ```
 
-If `kitaru-mcp` is not found, ensure the Python environment where Kitaru is
-installed is activated.
+If you are not using uv, configure the MCP host with the absolute path to the
+`kitaru-mcp` executable inside the Python environment. Do not rely on shell
+activation; many MCP hosts do not inherit the active terminal environment.
 
 ## Server executable
 
-The MCP server command is:
+The environment-safe server invocation is:
 
-```
-kitaru-mcp
+```bash
+uv run --directory <ABSOLUTE_PROJECT_PATH> kitaru-mcp
 ```
 
 It uses stdio transport by default.
@@ -42,7 +48,13 @@ Most hosts use a JSON configuration file with this schema:
 {
   "mcpServers": {
     "kitaru": {
-      "command": "kitaru-mcp"
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "<ABSOLUTE_PROJECT_PATH>",
+        "kitaru-mcp"
+      ]
     }
   }
 }
@@ -54,12 +66,21 @@ Some hosts require an explicit transport field:
 {
   "mcpServers": {
     "kitaru": {
-      "command": "kitaru-mcp",
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "<ABSOLUTE_PROJECT_PATH>",
+        "kitaru-mcp"
+      ],
       "transport": "stdio"
     }
   }
 }
 ```
+
+Replace `<ABSOLUTE_PROJECT_PATH>` with the full path to the project that has
+Kitaru installed, for example `/Users/alex/kitaru-quickstart-demo`.
 
 ## Available MCP tools
 
@@ -73,7 +94,7 @@ Once configured, the Kitaru MCP server exposes these tools:
 - `kitaru_executions_retry` — retry a failed execution
 - `kitaru_executions_replay` — replay from a checkpoint
 - `kitaru_executions_cancel` — cancel a running execution
-- `get_execution_logs` — read execution logs
+- `get_execution_logs` — read execution logs when the active log backend has entries
 - `kitaru_memory_list` — list memory entries in a known typed scope
 - `kitaru_memory_get` — read a memory value from a known typed scope
 - `kitaru_memory_set` — write a memory value
@@ -92,7 +113,12 @@ Once configured, the Kitaru MCP server exposes these tools:
 Memory tools operate on explicit typed scopes: provide both `scope` and
 `scope_type` for scoped memory calls. `kitaru_memory_get` supports `version`,
 and `kitaru_memory_list` supports `prefix`. MCP can work with a known memory
-scope, but it does not currently expose memory scope listing or memory reindexing.
+scope, but it does not currently expose memory scope listing or memory
+reindexing.
+
+For the quickstart's flow memory, use `scope_type="flow"` and the `flow_id`
+from `kitaru executions get <EXEC_ID> --output json`; do not assume the
+Python function name is the external memory scope.
 
 ## Authentication
 
@@ -100,4 +126,6 @@ The MCP server uses the same authentication context as the Kitaru CLI. If
 you are logged in via `kitaru login`, the MCP server will use those
 credentials.
 
-For local-only usage (no remote server), no login is needed.
+For local-only usage, run `kitaru login` only if you want the local server and
+dashboard. The MCP server can still inspect local project state through the
+same Kitaru environment.

--- a/skills/kitaru-quickstart/references/tracks/coding.py
+++ b/skills/kitaru-quickstart/references/tracks/coding.py
@@ -74,11 +74,27 @@ def coding_flow(issue: str) -> str:
     return result
 
 
+REPLAY_FROM = "generate_patch"
+DEFAULT_ISSUE = "fix null pointer in data processor"
+
+
+def _usage() -> None:
+    print("Usage: uv run python demo_flow.py [issue]")
+    print("       uv run python demo_flow.py --replay <EXEC_ID>")
+
+
 if __name__ == "__main__":
     import sys
 
-    issue = sys.argv[1] if len(sys.argv) > 1 else "fix null pointer in data processor"
-    handle = coding_flow.run(issue)
+    if len(sys.argv) > 1 and sys.argv[1] == "--replay":
+        if len(sys.argv) < 3:
+            _usage()
+            raise SystemExit(2)
+        handle = coding_flow.replay(sys.argv[2], from_=REPLAY_FROM)
+    else:
+        issue = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else DEFAULT_ISSUE
+        handle = coding_flow.run(issue)
+
     print(f"Execution ID: {handle.exec_id}")
     print(f"Status: {handle.status}")
     result = handle.wait()

--- a/skills/kitaru-quickstart/references/tracks/data.py
+++ b/skills/kitaru-quickstart/references/tracks/data.py
@@ -91,11 +91,27 @@ def data_flow(source: str) -> str:
     return result
 
 
+REPLAY_FROM = "transform"
+DEFAULT_SOURCE = "sales_data_2026_q1.csv"
+
+
+def _usage() -> None:
+    print("Usage: uv run python demo_flow.py [source]")
+    print("       uv run python demo_flow.py --replay <EXEC_ID>")
+
+
 if __name__ == "__main__":
     import sys
 
-    source = sys.argv[1] if len(sys.argv) > 1 else "sales_data_2026_q1.csv"
-    handle = data_flow.run(source)
+    if len(sys.argv) > 1 and sys.argv[1] == "--replay":
+        if len(sys.argv) < 3:
+            _usage()
+            raise SystemExit(2)
+        handle = data_flow.replay(sys.argv[2], from_=REPLAY_FROM)
+    else:
+        source = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else DEFAULT_SOURCE
+        handle = data_flow.run(source)
+
     print(f"Execution ID: {handle.exec_id}")
     print(f"Status: {handle.status}")
     result = handle.wait()

--- a/skills/kitaru-quickstart/references/tracks/research.py
+++ b/skills/kitaru-quickstart/references/tracks/research.py
@@ -66,11 +66,27 @@ def research_flow(topic: str) -> str:
     return result
 
 
+REPLAY_FROM = "draft_content"
+DEFAULT_TOPIC = "durable AI agents"
+
+
+def _usage() -> None:
+    print("Usage: uv run python demo_flow.py [topic]")
+    print("       uv run python demo_flow.py --replay <EXEC_ID>")
+
+
 if __name__ == "__main__":
     import sys
 
-    topic = sys.argv[1] if len(sys.argv) > 1 else "durable AI agents"
-    handle = research_flow.run(topic)
+    if len(sys.argv) > 1 and sys.argv[1] == "--replay":
+        if len(sys.argv) < 3:
+            _usage()
+            raise SystemExit(2)
+        handle = research_flow.replay(sys.argv[2], from_=REPLAY_FROM)
+    else:
+        topic = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else DEFAULT_TOPIC
+        handle = research_flow.run(topic)
+
     print(f"Execution ID: {handle.exec_id}")
     print(f"Status: {handle.status}")
     result = handle.wait()

--- a/skills/kitaru-quickstart/references/tracks/support.py
+++ b/skills/kitaru-quickstart/references/tracks/support.py
@@ -71,11 +71,27 @@ def support_flow(ticket: str) -> str:
     return result
 
 
+REPLAY_FROM = "draft_response"
+DEFAULT_TICKET = "billing charge incorrect on invoice #1234"
+
+
+def _usage() -> None:
+    print("Usage: uv run python demo_flow.py [ticket]")
+    print("       uv run python demo_flow.py --replay <EXEC_ID>")
+
+
 if __name__ == "__main__":
     import sys
 
-    ticket = sys.argv[1] if len(sys.argv) > 1 else "billing charge incorrect on invoice #1234"
-    handle = support_flow.run(ticket)
+    if len(sys.argv) > 1 and sys.argv[1] == "--replay":
+        if len(sys.argv) < 3:
+            _usage()
+            raise SystemExit(2)
+        handle = support_flow.replay(sys.argv[2], from_=REPLAY_FROM)
+    else:
+        ticket = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else DEFAULT_TICKET
+        handle = support_flow.run(ticket)
+
     print(f"Execution ID: {handle.exec_id}")
     print(f"Status: {handle.status}")
     result = handle.wait()

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -56,7 +56,7 @@ user-facing surfaces:
   pending_waits / input / abort_wait / retry / resume / replay / cancel`,
   `artifacts.list / get`, and `memories.get / list / history / set / delete /
   scopes / compact / purge / purge_scope / compaction_log / reindex`
-- **CLI control**: `kitaru login`, `kitaru run`, `kitaru executions ...`,
+- **CLI control**: `kitaru login`, `kitaru executions ...`,
   `kitaru memory scopes/list/get/set/delete/history/compact/purge/purge-scope/
   compaction-log/reindex`, stack/model/secret commands (including remote stack
   creation for `kubernetes`, `vertex`, `sagemaker`, `azureml`), and runtime
@@ -104,8 +104,9 @@ the handles people use to inspect or patch durable state later.
 
 Not every surface can do every job:
 
-- **Launching executions**: SDK flow objects (`.run()`), CLI
-  (`kitaru run`), MCP (`kitaru_executions_run`) — **not** `KitaruClient`
+- **Launching executions**: SDK flow objects (`.run()`) or a Python entrypoint,
+  MCP (`kitaru_executions_run`) — **not** `KitaruClient`, and not a top-level
+  CLI `kitaru run` command
 - **Inspecting/controlling executions**: `KitaruClient`, CLI, MCP
 - **Using module-level memory inside flow code**: SDK `kitaru.memory`
 - **Explicit typed-scope memory administration**: `KitaruClient`, CLI, MCP
@@ -282,7 +283,9 @@ a drop-in replacement for replay-stable artifacts.
 When memory is the right fit, choose the scope deliberately:
 
 - **namespace**: shared durable state across many executions, users, or agents
-- **flow**: state that naturally belongs to one flow name
+- **flow**: state that naturally belongs to one flow identity. Operator
+  surfaces may expose this as a flow ID, so capture the exact scope value from
+  execution details or memory-scope discovery.
 - **execution**: state isolated to one run but still key-addressable
 
 Important asymmetry to remember:
@@ -353,7 +356,7 @@ Important asymmetries to account for in the design:
 
 | Capability | SDK | KitaruClient | CLI | MCP |
 |---|---|---|---|---|
-| Launch new execution | Yes (flow object) | No | Yes | Yes |
+| Launch new execution | Yes (flow object / Python entrypoint) | No | No top-level run command | Yes |
 | Inspect execution | Limited | Yes | Yes | Yes |
 | Resolve wait input | No | Yes | Yes | Yes |
 | Abort wait | No | Yes | No | No |
@@ -515,7 +518,7 @@ guide.
 - **Not a Kitaru concern**: [pieces that should stay outside the flow]
 
 ## Operator Surface
-- **Launch / deploy**: [SDK flow object | CLI | MCP] (not KitaruClient)
+- **Launch / deploy**: [SDK flow object / Python entrypoint | MCP] (not KitaruClient; not CLI)
 - **Logs / inspection**: [KitaruClient | CLI | MCP]
 - **Wait input**: [KitaruClient | CLI | MCP]
 - **Wait abort**: [KitaruClient] (only surface with abort_wait)


### PR DESCRIPTION
## What changed

- Reworked `/kitaru-quickstart` into a slower, dashboard-first tutorial flow with explicit pause/inspection points after writing code and after each phase.
- Updated setup guidance to install `kitaru[local,mcp]>=0.4.0`, avoid uv ancestor `exclude-newer` traps, start the local server with `kitaru login`, and direct users to the dashboard at `http://127.0.0.1:8383`.
- Added `--replay <EXEC_ID>` helpers to the quickstart track templates and documented the `PYTHONPATH=.` CLI replay workaround.
- Fixed stale command guidance for wait input, flow-scoped memory inspection, logs expectations, MCP configuration, and cleanup/teardown.
- Updated MCP host docs to use `uv run --directory <ABSOLUTE_DEMO_DIR> kitaru-mcp` instead of a bare `kitaru-mcp` executable.
- Tightened related authoring/scoping wording around launch surfaces and flow memory scope identity.

## Why

A real end-to-end run of the quickstart showed that the experience moved too quickly for a tutorial and included several command/API inaccuracies. The revised flow teaches the concepts more deliberately and avoids known pitfalls around local server extras, wait input, replay, memory scopes, sparse logs, and uv-managed MCP environments.

Closes #5.

## Validation

- `git diff --check`
- Python syntax compilation for all quickstart track templates without writing bytecode
- Markdown fence and JSON snippet validation script
- Stale-string searches for the old invalid command patterns
- Oracle review pass for the multi-file skill/template changes
