### PR TITLE
Remove Kitaru memory references from skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Skills for designing and building durable AI agent workflows with Kitaru",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
   },
@@ -15,8 +15,8 @@
     {
       "name": "kitaru",
       "source": "./",
-      "description": "Bundles three Kitaru skills: kitaru-quickstart (interactive onboarding with crash-recovery, wait(), and durable memory demos), kitaru-scoping (validates Kitaru fit and outputs a flow_architecture.md), and kitaru-authoring (reference for flows, checkpoints, waits, KitaruClient, CLI, MCP, and PydanticAI integration).",
-      "version": "0.4.1",
+      "description": "Bundles three Kitaru skills: kitaru-quickstart (interactive onboarding with crash-recovery, wait(), and artifact/log inspection demos), kitaru-scoping (validates Kitaru fit and outputs a flow_architecture.md), and kitaru-authoring (reference for flows, checkpoints, waits, KitaruClient, CLI, MCP, and PydanticAI integration).",
+      "version": "0.4.2",
       "author": {
         "name": "ZenML",
         "url": "https://kitaru.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
   "description": "Kitaru skills for Claude Code: quickstart (interactive onboarding), scoping (flow architecture design), and authoring (writing durable agent workflows)",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,6 @@ There is currently no dedicated automated test suite. Treat testing as documenta
 - Re-read edited Markdown in rendered form when possible to catch broken lists, code fences, or tables.
 
 ## Commit & Pull Request Guidelines
-Recent history uses short, imperative commit messages such as `Update skills for Kitaru memory support` and `Align skills with current Kitaru SDK surface`. Follow that pattern.
+Recent history uses short, imperative commit messages such as `Update quickstart flow templates` and `Align skills with current Kitaru SDK surface`. Follow that pattern.
 
 Pull requests should explain what changed, why it changed, and which files were updated. If you alter behavior or installation steps, update `README.md` in the same PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,12 @@ skills/
   kitaru-quickstart/SKILL.md       # Interactive onboarding → demo flow
   kitaru-quickstart/references/    # Track templates, host guides, MCP config
   kitaru-scoping/SKILL.md          # Structured interview → flow_architecture.md
-  kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, memory, etc.
+  kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, artifacts, etc.
 ```
 
-- **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory, and optional MCP integration.
-- **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
-- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
+- **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
+- **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
+- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
 
 The intended user workflow is: quickstart → scope → author.
 
@@ -33,7 +33,7 @@ There is no build step, no linter, no test suite. The deliverables are the two `
 
 1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
 2. **Completeness of asymmetry tables** — the skills document capability differences across four surfaces (SDK, KitaruClient, CLI, MCP). These tables must stay synchronized between the two skill files.
-3. **Stable naming** — checkpoint names, wait names, memory scopes, and operator handles are first-class concepts. Changes to naming conventions in the skills ripple into generated architecture documents.
+3. **Stable naming** — checkpoint names, wait names, artifact names, and operator handles are first-class concepts. Changes to naming conventions in the skills ripple into generated architecture documents.
 
 ## Key constraints when editing skills
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ The intended user workflow is: quickstart → scope → author.
 
 ## How to work on this repo
 
-There is no build step, no linter, no test suite. The deliverables are the two `SKILL.md` files. Quality comes from:
+There is no build step, no linter, no test suite. The deliverables are the three `SKILL.md` files plus the quickstart reference templates and setup guides. Quality comes from:
 
 1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
 2. **Completeness of asymmetry tables** — the skills document capability differences across four surfaces (SDK, KitaruClient, CLI, MCP). These tables must stay synchronized between the two skill files.

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Add to your project's `.claude/settings.json`:
 ### Manual installation
 
 ```bash
-mkdir -p .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-scoping/SKILL.md \
-  -o .claude/skills/kitaru-scoping/SKILL.md
-
-curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/kitaru-authoring/SKILL.md \
-  -o .claude/skills/kitaru-authoring/SKILL.md
+tmpdir=$(mktemp -d)
+git clone --depth 1 https://github.com/zenml-io/kitaru-skills.git "$tmpdir/kitaru-skills"
+mkdir -p .claude/skills
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-quickstart" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-scoping" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-authoring" .claude/skills/
+rm -rf "$tmpdir"
 ```
 
 ## Example prompts

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ discovering, designing, and building durable AI agent workflows with
 
 | Skill | Slash command | Purpose |
 |---|---|---|
-| **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, durable memory across executions, and optional MCP integration |
-| **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, memory-vs-artifact strategy, memory scope design, operator surface, MVP scope) |
-| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `kitaru.memory`, `KitaruClient.memories`, replay/resume/retry, CLI memory commands, MCP memory tools, and PydanticAI adapter integrations |
+| **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
+| **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
+| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, CLI commands, MCP tools, and PydanticAI adapter integrations |
 
 ### Recommended workflow
 
 1. **Quickstart** — use `/kitaru-quickstart` to see what Kitaru does and
-   build intuition for crash recovery, replay, wait, and memory
+   build intuition for crash recovery, replay, waits, and artifacts
 2. **Scope** — use `/kitaru-scoping` to validate fit and define your flow
    architecture before writing code
 3. **Author** — use `/kitaru-authoring` to build the flows defined in
@@ -72,14 +72,14 @@ curl -fsSL https://raw.githubusercontent.com/zenml-io/kitaru-skills/main/skills/
 **Scoping:**
 - "I want to build a research agent — is Kitaru right for this?"
 - "Help me figure out where to put checkpoints in my coding agent workflow."
-- "Should repo conventions live in memory or artifacts?"
+- "Should repo conventions be stored as explicit artifacts or outside the flow?"
 - "I have a complex agent with 10 steps — help me scope it down."
 
 **Authoring:**
 - "Refactor this script into one `@flow` with explicit checkpoints."
 - "Add a flow-level `kitaru.wait()` approval gate before publish."
-- "Add `kitaru.memory` durable shared state to this flow."
-- "How do I seed memory from a script and inspect it from the CLI or MCP?"
+- "Add explicit artifact saving to this flow."
+- "How do I inspect executions, waits, logs, and artifacts from the CLI or MCP?"
 - "Wrap this PydanticAI call in a `@checkpoint` and preserve replay safety."
 
 ## Links

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -1,44 +1,36 @@
 ---
 name: kitaru-authoring
 description: >
-  Guide for writing Kitaru durable workflows, durable shared memory, and
-  operational control paths. Use when creating or refactoring Kitaru flows,
-  checkpoints, waits, logging, artifacts, `kitaru.memory`,
-  `KitaruClient.memories`, tracked LLM calls, replay/resume/retry flows,
-  KitaruClient usage, CLI commands, MCP operations, or PydanticAI adapter
-  integrations. Triggers on mentions of kitaru, @flow, @checkpoint,
-  kitaru.wait, kitaru.log, kitaru.save, kitaru.load, kitaru.memory,
-  memory.configure, memory.get, memory.set, memory.list, memory.history,
-  memory.delete, KitaruClient, KitaruClient.memories, replay, resume, retry,
-  `kitaru executions ...`, `kitaru memory ...`, MCP tools,
-  `kitaru_memory_*`, `wrap(...)`, or `hitl_tool(...)`.
+  Guide for writing Kitaru durable workflows and operational control paths. Use
+  when creating or refactoring Kitaru flows, checkpoints, waits, logging,
+  artifacts, tracked LLM calls, replay/resume/retry flows, KitaruClient usage,
+  CLI commands, MCP operations, or PydanticAI adapter integrations. Triggers on
+  mentions of kitaru, @flow, @checkpoint, kitaru.wait, kitaru.log,
+  kitaru.save, kitaru.load, KitaruClient, replay, resume, retry,
+  `kitaru executions ...`, MCP tools, `wrap(...)`, or `hitl_tool(...)`.
 ---
 
 # Kitaru Authoring Skill
 
 Use this guide when writing or refactoring Kitaru workflows and when choosing
 which Kitaru surface to use for running, observing, replaying, controlling, or
-persisting durable state for those workflows.
+inspecting durable state for those workflows.
 
 > **Before building**: If the workflow shape is still fuzzy, suggest the
 > `kitaru-scoping` skill first. It helps the user decide whether Kitaru is a
-> fit, where checkpoints and waits belong, whether memory or artifacts should
-> hold shared state, and which replay anchors should be stable before code gets
-> written.
+> fit, where checkpoints and waits belong, which values should become explicit
+> artifacts, and which replay anchors should be stable before code gets written.
 
 ## Mental model
 
-Think of a Kitaru flow like a long trip with named save points and a shared
-cabinet of durable facts.
+Think of a Kitaru flow like a long trip with named save points and labeled boxes for durable outputs.
 
 - `@flow` is the durable outer boundary.
 - `@checkpoint` is a replay boundary inside that flow.
 - `wait()` pauses at the flow level and resumes later with input.
 - Replay reruns from the top, but checkpoints before the selected replay point
   return cached outputs instead of doing the work again.
-- Artifacts are boxes tied to a specific execution or checkpoint.
-- Memory is the shared cabinet: durable values stored under stable
-  `scope_type + scope + key` names.
+- Artifacts are labeled boxes tied to a specific execution or checkpoint.
 - Flows are executed with `.run(...)`, not by calling the decorated function
   directly.
 
@@ -76,22 +68,15 @@ Enforce these rules when writing or reviewing Kitaru code:
 2. Do not call one checkpoint from inside another checkpoint.
 3. Do not call `wait()` inside a checkpoint.
 4. `save()` and `load()` require checkpoint scope.
-5. `kitaru.memory.*` is allowed in the flow body but forbidden inside a
-   checkpoint.
-6. Outside a flow, configure an active scope before using `memory.get()`,
-   `memory.set()`, `memory.list()`, `memory.history()`, or `memory.delete()`;
-   `memory.configure(scope=...)` defaults to `scope_type="namespace"`.
-7. The module-level `kitaru.memory` API uses the active configured typed scope;
-   it does not take per-call `scope=` or `scope_type=` arguments.
-8. `log()` works in flow scope and checkpoint scope, but it attaches metadata to
+5. `log()` works in flow scope and checkpoint scope, but it attaches metadata to
    different targets depending on where it runs.
-9. Checkpoint outputs must be serializable.
-10. `.submit()`, `.map()`, and `.product()` are for work launched from inside a
-    running flow.
-11. `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
-    synthetic `llm_call` checkpoint automatically.
-12. Use stable, unique names for checkpoints, waits, artifacts, memory scopes,
-    and important memory keys so replay and operations stay unambiguous.
+6. Checkpoint outputs must be serializable.
+7. `.submit()`, `.map()`, and `.product()` are for work launched from inside a
+   running flow.
+8. `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
+   synthetic `llm_call` checkpoint automatically.
+9. Use stable, unique names for checkpoints, waits, and artifacts so replay and
+   operations stay unambiguous.
 
 ## Primitive reference
 
@@ -150,89 +135,26 @@ inspection or reuse.
   `output`, `blob`
 - Keep artifact names unique within an execution to avoid ambiguous loads
 
-### `memory`
+### Durable state beyond one execution
 
-Use `kitaru.memory` for durable shared state addressed by stable keys within one
-active configured typed scope (`scope_type` + `scope`).
+Kitaru's current shipped public surface does not include a native key-value
+state API. If a workflow needs information to survive across executions, choose
+one of these explicit patterns instead:
 
-Public module-level API:
+- Save execution-linked values with `save(...)` inside checkpoints and inspect
+  them later through `KitaruClient.artifacts` or MCP artifact tools.
+- Pass upstream execution IDs into downstream flows when one flow needs to load
+  another flow's artifacts.
+- Store global preferences, configuration, or mutable application data in an
+  external system such as a database, object store, repository file, or service
+  API.
+- Use Kitaru secrets for sensitive configuration and `llm(...)` aliases, not for
+  arbitrary workflow state.
 
-- `memory.configure(scope: str | None = None, *, scope_type: "namespace" | "flow" | "execution" | None = None)`
-- `memory.set(key, value)`
-- `memory.get(key, *, version=None)`
-- `memory.list()`
-- `memory.history(key)`
-- `memory.delete(key)`
-
-Key behavior to teach correctly:
-
-- Valid in the flow body
-- Invalid inside checkpoints
-- Inside a flow, the default scope is the active flow identity unless you
-  configured a different active scope. Operator surfaces may expose that flow
-  identity as a flow ID, so use execution details or `memory scopes` to find
-  the exact external scope value.
-- Outside a flow, configure an active scope first; `memory.configure(scope=...)`
-  defaults to `scope_type="namespace"`
-- `memory.configure(scope_type="namespace")` still requires an explicit
-  `scope=...`, while `scope_type="flow"` and `scope_type="execution"` can only
-  be inferred inside a `@flow`
-- The module API uses the active typed scope; do not invent per-call `scope=` or
-  `scope_type=` support
-- In flow code, reads like `memory.get()` behave like runtime step outputs, so
-  keep memory calls in the flow body and pass their results into checkpoints
-  when you need normal Python logic
-- Deletes are soft deletes, so `history(...)` includes tombstones
-- Maintenance operations are **not** module-level APIs: do not invent
-  `memory.compact()`, `memory.purge()`, `memory.purge_scope()`,
-  `memory.compaction_log()`, or `memory.reindex()`
-- Replay is not fully memory-frozen: replays may observe newer values, and
-  replayed writes create new versions
-
-A good pattern is to keep the memory calls in the flow body, then pass the
-result into a checkpoint when you want normal Python logic:
-
-```python
-from kitaru import checkpoint, flow, memory
-
-@checkpoint
-def increment_runs(previous_runs: int | None) -> int:
-    return (previous_runs or 0) + 1
-
-@flow
-def research_agent(topic: str) -> None:
-    previous_runs = memory.get("stats/run_count")
-    updated_runs = increment_runs(previous_runs)
-    memory.set("stats/run_count", updated_runs)
-    memory.set("last_topic", topic)
-```
-
-Outside a flow, configure first:
-
-```python
-from kitaru import memory
-
-memory.configure(scope="repo_docs", scope_type="namespace")
-memory.set("style/release_notes", {"tone": "concise"})
-```
-
-Switch to `KitaruClient.memories` when you need explicit typed-scope
-administration, prefix filtering, scope listing, maintenance operations, or
-memory inspection outside the active-scope module model.
-
-Maintenance lives on `KitaruClient`, CLI, and MCP surfaces:
-
-- `compact` sends selected memory values to an LLM and writes the summary as a
-  new memory version; it does not delete source entries. Single-key compaction
-  defaults to `source_mode="current"`, can use `source_mode="history"`, and
-  multi-key compaction summarizes current values into a required target key.
-- `purge` / `purge_scope` physically delete old versions; delete is only a
-  tombstone.
-- `compaction_log` reads compact/purge audit records.
-- `reindex` is project-scoped, dry-run by default, additive tag backfill for
-  historical memory discovery; it does not rewrite memory values.
-- `compact` uses an LLM, so make sure a default model or explicit `model=` /
-  `--model` is available.
+Do not invent SDK helpers, CLI commands, or MCP tools for removed native
+key-value state. When replay correctness matters, make the critical value an
+explicit checkpoint output or saved artifact so the exact value from the source
+execution remains inspectable.
 
 ### `llm(...)`
 
@@ -298,33 +220,20 @@ in every interface.
 ### SDK (flow objects + helpers)
 
 - Author flows and checkpoints
-- Use `wait`, `log`, `save`, `load`, `llm`, `memory.configure`, `memory.set`,
-  `memory.get`, `memory.list`, `memory.history`, `memory.delete`
+- Use `wait`, `log`, `save`, `load`, and `llm`
 - Use `configure(...)`, `connect(server_url, ...)`, `list_stacks()`,
   `current_stack()`, `use_stack()`, `create_stack(...)` (**local stacks only**),
   `delete_stack(...)`
 - Launch executions: `flow.run(...)`, `flow.replay(...)`
 
-### KitaruClient (execution control + explicit memory/artifact inspection)
+### KitaruClient (execution control + artifact inspection)
 
-The client is for **managing existing executions** and for **explicit typed-scope
-memory/artifact administration**, not for launching new executions.
+The client is for **managing existing executions** and for **artifact
+inspection**, not for launching new executions.
 
 - `executions.get / list / latest / logs / pending_waits / input / abort_wait /
   retry / resume / replay / cancel`
 - `artifacts.list / get`
-- `memories.get / list(prefix=...) / history / set / delete / scopes / purge /
-  purge_scope / compact / compaction_log / reindex`
-  - Scoped memory calls require explicit `scope=` and `scope_type=`.
-  - `get(..., version=...)` supports versioned reads.
-  - `compact`, `purge`, `purge_scope`, and `compaction_log` are typed-scope
-    maintenance operations.
-  - `reindex(apply=False)` is project-scoped, dry-run by default, and backfills
-    missing memory discovery tags for historical data.
-  - `memories.get(...)`, `list(...)`, and `history(...)` return memory-entry
-    metadata; load values with
-    `client.artifacts.get(entry.artifact_id).load()`. Module-level
-    `memory.get(...)` returns the stored value directly.
 
 ### CLI
 
@@ -339,21 +248,6 @@ memory/artifact administration**, not for launching new executions.
 - `model register / list`
 - `secrets set / show / list / delete`
 - `executions get / list / logs / input / replay / retry / resume / cancel`
-- `memory scopes`; `memory list/get/set/delete/history`; `memory compact`;
-  `memory purge`; `memory purge-scope`; `memory compaction-log`;
-  `memory reindex`
-  - All scoped memory commands require both `--scope` and `--scope-type`.
-  - `memory scopes` and `memory reindex` are unscoped/project-scoped commands.
-  - `memory set` parses JSON when possible; otherwise it stores the raw string.
-  - CLI memory does not expose versioned `get` or prefix-filtered `list`.
-  - `memory compact` summarizes selected memory values with an LLM and writes a
-    new memory version; it may need a configured default model or `--model`.
-  - `memory purge` physically deletes old versions of one key.
-  - `memory purge-scope` physically deletes old versions across a scope;
-    `--include-deleted` also removes tombstoned keys.
-  - `memory compaction-log` reads compact/purge audit records.
-  - `memory reindex` is dry-run by default; use `--apply` to persist missing
-    discovery tags.
 - JSON output contract: `--output json` / `-o json` emits
   `{command, item}` for single-item commands, `{command, items, count}` for
   lists, and JSONL event objects for `executions logs --follow --output json`
@@ -366,15 +260,6 @@ memory/artifact administration**, not for launching new executions.
   `kitaru_executions_replay`, `kitaru_executions_cancel`
 - `get_execution_logs`
 - `kitaru_artifacts_list`, `kitaru_artifacts_get`
-- `kitaru_memory_list`, `kitaru_memory_get`, `kitaru_memory_set`,
-  `kitaru_memory_delete`, `kitaru_memory_history`
-- `kitaru_memory_compact`, `kitaru_memory_purge`,
-  `kitaru_memory_purge_scope`, `kitaru_memory_compaction_log`
-  - MCP memory tools use explicit typed scopes: every scoped memory tool takes
-    `scope` and `scope_type`.
-  - `kitaru_memory_get` supports `version`; `kitaru_memory_list` supports
-    `prefix`.
-  - MCP does not expose memory scope listing or memory reindexing.
 - `kitaru_status`, `kitaru_stacks_list`
 - `manage_stack` (create/delete; supports `local`, `kubernetes`, `vertex`,
   `sagemaker`, `azureml`, plus `extra` and `async_mode`)
@@ -394,23 +279,6 @@ memory/artifact administration**, not for launching new executions.
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
 | Switch active stack | Yes | No | Yes | No |
-
-### Memory-specific asymmetries
-
-| Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
-|---|---|---|---|---|
-| In-flow memory reads/writes | Yes | No | No | No |
-| Outside-flow seed/update | Yes, after `memory.configure(...)` | Yes | Yes | Yes |
-| Active-scope Python API | Yes | No | No | No |
-| Explicit typed-scope admin (`scope` + `scope_type`) | No | Yes | Yes | Yes |
-| List memory scopes | No | Yes (`memories.scopes()`) | Yes (`kitaru memory scopes`) | No |
-| Read a specific version | Yes (`memory.get(version=...)`) | Yes | No | Yes |
-| Prefix-filter a list | No | Yes (`memories.list(..., prefix=...)`) | No | Yes |
-| Compact memory | No | Yes | Yes | Yes |
-| Purge one key | No | Yes | Yes | Yes |
-| Purge a whole scope | No | Yes | Yes | Yes |
-| Read compaction/purge audit log | No | Yes | Yes | Yes |
-| Reindex historical memory tags | No | Yes (`reindex(apply=False)`) | Yes (`kitaru memory reindex`) | No |
 
 ## Connection and runtime context
 
@@ -484,39 +352,18 @@ def my_flow(topic: str) -> str:
 
 - Calling `my_flow(...)` directly instead of `my_flow.run(...)`
 - Putting `wait()` inside a checkpoint
-- Calling `memory.*` inside a checkpoint
-- Passing `scope=` or `scope_type=` to module-level `kitaru.memory` calls even
-  though the module API uses the active configured typed scope
-- Forgetting to configure an active scope before module-level memory use outside
-  flows; `memory.configure(scope=...)` defaults to `scope_type="namespace"`
-- Describing memory identity as only a `scope` when the operation requires
-  `scope_type + scope + key`
-- Forgetting `--scope-type` on CLI memory commands
-- Assuming CLI or MCP memory commands infer a default scope
-- Assuming MCP can list memory scopes or run memory reindexing
-- Trying to call maintenance operations on module-level `kitaru.memory`
-- Assuming `compact` deletes source entries; it writes a summary, then `purge`
-  is a separate hard-delete step
-- Treating `delete` and `purge` as interchangeable: delete writes a tombstone;
-  purge physically removes versions
-- Treating `KitaruClient.memories.get(...)` as the raw stored value rather than
-  entry metadata
-- Using invalid memory keys/scopes; use letters, numbers, `.`, `_`, `-`, and
-  `/`, and avoid `:`
-- Using memory for execution-linked outputs that should be explicit artifacts
-- Assuming memory is replay-deterministic across replays
 - Nesting checkpoint calls
 - Returning non-serializable values from checkpoints
 - Calling `llm()` outside a `@flow`
 - Using vague or duplicate checkpoint / wait names that make replay selectors
   hard to target
 - Reusing artifact names so `load()` becomes ambiguous
-- Reusing unstable memory scope or key names so operators cannot inspect state
-  later
+- Inventing removed key-value state APIs instead of using artifacts or an
+  external store
 - Using `wait.*` override keys in replay (they are not supported)
 - Assuming CLI, client, and MCP expose the same operation set
 - Using `KitaruClient` to launch new executions (it's for
-  inspection/control/memory admin only)
+  inspection/control only)
 - Using `connect(...)` and expecting managed workspace support (use
   `kitaru login` for that)
 - Using SDK `create_stack(...)` for remote stacks (it's local-only; use

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -559,7 +559,7 @@ the session:
 - **Flow**: [flow name] with [N] checkpoints
 - **Demo directory**: [absolute path]
 - **Dashboard**: http://127.0.0.1:8383
-- **Demonstrated**: crash recovery, replay[, wait(), MCP]
+- **Demonstrated**: crash recovery, replay[, wait(), artifact capture, MCP]
 
 ## Commands worth remembering
 

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -3,7 +3,7 @@ name: kitaru-quickstart
 description: >
   Interactive onboarding for new Kitaru users. Scaffolds a personalized demo
   flow, demonstrates crash recovery with replay, human-in-the-loop with
-  wait(), durable memory across executions, and optional MCP integration.
+  wait(), artifact capture, and optional MCP integration.
   Use when a user mentions kitaru quickstart, getting started with kitaru,
   kitaru demo, kitaru onboarding, try kitaru, learn kitaru, what is kitaru,
   show me kitaru, kitaru tutorial, or wants to see what Kitaru does.
@@ -13,7 +13,7 @@ description: >
 
 Build and run a working Kitaru demo tailored to the user's domain. Take
 someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
-wait, memory, and the dashboard" in a single teaching session.
+waits, artifacts, and the dashboard" in a single teaching session.
 
 > **Relationship to other skills**:
 > - `/kitaru-quickstart` → activation and intuition (this skill)
@@ -69,8 +69,8 @@ then offer `/kitaru-authoring` for PydanticAI conversion.
 | Depth              | Phases              |
 |--------------------|---------------------|
 | Five-minute tour   | 0 → 1 → 5          |
-| Guided build       | 0 → 1 → 2 → 2.5 → 3 → 5 |
-| Guided build + MCP | 0 → 1 → 2 → 2.5 → 3 → 4 → 5 |
+| Guided build       | 0 → 1 → 2 → 3 → 5 |
+| Guided build + MCP | 0 → 1 → 2 → 3 → 4 → 5 |
 
 ## Tutorial pacing rules
 
@@ -140,8 +140,8 @@ This is a tutorial, not a firehose. Throughout the session:
    If `uv add` says only an older Kitaru version is available, explain that
    an ancestor `exclude-newer` setting may be filtering PyPI. Move the demo
    to a neutral path and retry. If it still fails, stop with the clear
-   message that this quickstart needs Kitaru `>=0.4.0` because it uses
-   module-level `kitaru.memory`.
+   message that this quickstart needs Kitaru `>=0.4.0` because it expects the
+   current local server, replay, wait, artifact, and MCP surfaces.
 
 4. **Initialize and verify Kitaru**:
    ```bash
@@ -160,8 +160,8 @@ This is a tutorial, not a firehose. Throughout the session:
    > "Kitaru's local server should now be running. Open
    > http://127.0.0.1:8383 in your browser. Take a minute to look around —
    > the dashboard is where you'll be able to see executions, checkpoints,
-   > waits, and replay behavior visually. Tell me when you've had a look and
-   > we'll continue."
+   > waits, artifacts, and replay behavior visually. Tell me when you've had a
+   > look and we'll continue."
 
    Pause here and wait for acknowledgement. If local server startup fails
    because local dependencies are missing, rerun
@@ -192,7 +192,7 @@ domain choice:
 Adapt variable names, mock data, and print statements to the user's domain.
 
 **CRITICAL**: Do NOT alter the placement, arguments, or syntax of `@flow`,
-`@checkpoint`, `wait()`, `log()`, `memory.*`, or the `--replay` helper. Only
+`@checkpoint`, `wait()`, `log()`, `save()`, or the `--replay` helper. Only
 customize the internal business logic of checkpoint functions: string
 content, mock data values, and explanatory print text.
 
@@ -218,8 +218,8 @@ for these items:
 
 - the `@flow` function: this is the durable orchestration boundary;
 - the `@checkpoint` functions: these are replay save points;
-- `memory.get(...)` and `memory.set(...)`: these deliberately live in the
-  flow body, not inside checkpoints;
+- `log(...)` and `save(...)`: these leave inspectable breadcrumbs and
+  artifacts for later debugging;
 - the simulated crash in the second meaningful checkpoint;
 - the `wait(...)` gate that will pause for human input later;
 - the `--replay <EXEC_ID>` helper at the bottom of the file.
@@ -386,89 +386,7 @@ Then summarize:
 > long-running agent workflows can include human approval without babysitting
 > a live process."
 
-Ask whether the user wants to continue to memory or discuss waits first.
-
----
-
-## Phase 2.5: Durable memory demo
-
-### Step 1: Explain memory
-
-> "Kitaru memory lets a flow remember small pieces of state across
-> executions. In this demo, the flow records the last topic/issue/source/ticket
-> after approval, then reads it at the start of the next run."
-
-### Step 2: Run the flow again with different input
-
-Choose a different argument that makes sense for the track:
-
-| Track            | Example second input              |
-|------------------|-----------------------------------|
-| Research/content | `"quantum computing"`             |
-| Coding agent     | `"optimize database query speed"` |
-| Data pipeline    | `"inventory_data_2026_q2.csv"`    |
-| Support/triage   | `"login page returns 500 error"`  |
-
-```bash
-uv run python demo_flow.py "<new input>"
-```
-
-If the dashboard or log backend shows the early
-`log(returning_user=True, ...)` metadata, point it out. If logs are sparse,
-do not treat that as a failure — the durable proof comes from the CLI memory
-inspection in the next steps. If the run pauses at `wait()`, resolve it with
-the Phase 2 command so the final `memory.set(...)` call can write the new
-value.
-
-### Step 3: Find the flow UUID for CLI memory inspection
-
-Inside the flow body, module-level `kitaru.memory` resolves the active flow
-scope automatically. Outside the flow, CLI/MCP/Client calls need an explicit
-typed scope. For this quickstart, use the **flow UUID**, not the Python
-function name.
-
-Get the execution details:
-
-```bash
-uv run kitaru executions get <EXEC_ID> --output json
-```
-
-Extract `item.flow_id` from the JSON. If that is not obvious, run:
-
-```bash
-uv run kitaru memory scopes --output json
-```
-
-and choose the row where `scope_type` is `flow` and the scope corresponds to
-the demo flow. Do not use `research_flow`, `coding_flow`, `data_flow`, or
-`support_flow` as the CLI scope unless the current CLI explicitly reports
-that exact value as the scope.
-
-### Step 4: Inspect memory from the CLI
-
-```bash
-uv run kitaru memory list --scope <FLOW_ID> --scope-type flow
-uv run kitaru memory get <MEMORY_KEY> --scope <FLOW_ID> --scope-type flow
-```
-
-Memory scope and key names by track:
-
-| Track            | Flow function in code | Scope type | CLI scope value                  | Memory key    |
-|------------------|-----------------------|------------|----------------------------------|---------------|
-| Research/content | `research_flow`       | `flow`     | `flow_id` from execution details | `last_topic`  |
-| Coding agent     | `coding_flow`         | `flow`     | `flow_id` from execution details | `last_issue`  |
-| Data pipeline    | `data_flow`           | `flow`     | `flow_id` from execution details | `last_source` |
-| Support/triage   | `support_flow`        | `flow`     | `flow_id` from execution details | `last_ticket` |
-
-### Step 5: Explain
-
-> "The code had the easy experience: inside the flow, memory knew which flow
-> it belonged to. Operator tools need the explicit typed scope, so we used the
-> flow UUID. This is like the difference between saying 'my house' while
-> you're standing in it and giving someone the exact street address from
-> outside."
-
-Ask whether the user wants to continue to the CLI inspection tour.
+Ask whether the user wants to continue to the CLI inspection tour or discuss waits first.
 
 ---
 
@@ -503,12 +421,21 @@ local stack, log output may be sparse or say "No log entries found" depending
 on the active log store and runtime setup. That is not a quickstart failure;
 fall back to `executions get` and the dashboard.
 
-### Step 4: Explain
+### Step 4: Inspect saved artifacts in the dashboard
+
+The templates call `save(...)` inside the final checkpoint after approval. Ask
+the user to open the completed execution in the dashboard and look for the saved
+artifact from the final checkpoint.
+
+Explain that the CLI is focused on execution control and logs; for scriptable
+artifact inspection, use KitaruClient or MCP artifact tools.
+
+### Step 5: Explain
 
 > "The dashboard is the visual way to understand what happened. The CLI is
-> the scriptable way to inspect the same executions, waits, checkpoints, and
-> failures. Logs are useful when the active log backend captures them, but
-> execution details are the dependable baseline."
+> the scriptable way to inspect executions, waits, checkpoints, and failures.
+> Logs are useful when the active log backend captures them, while saved
+> artifacts are the durable boxes you can inspect later."
 
 End with a short recap and ask before continuing.
 
@@ -605,9 +532,7 @@ If a wait is currently pending, also demonstrate:
 If applicable:
 5. **Replay** — trigger a replay via MCP
 
-For MCP memory tools, remind the user that scoped memory calls require both
-`scope_type` and `scope`. For this quickstart, use `scope_type="flow"` and the
-flow UUID discovered in Phase 2.5.
+Keep the MCP demo focused on executions, wait input, replay, logs, and artifact inspection.
 
 ### Step 8: Handle failure
 
@@ -634,7 +559,7 @@ the session:
 - **Flow**: [flow name] with [N] checkpoints
 - **Demo directory**: [absolute path]
 - **Dashboard**: http://127.0.0.1:8383
-- **Demonstrated**: crash recovery, replay[, wait(), memory, MCP]
+- **Demonstrated**: crash recovery, replay[, wait(), MCP]
 
 ## Commands worth remembering
 
@@ -644,7 +569,6 @@ uv run kitaru executions list
 uv run kitaru executions get <EXEC_ID>
 uv run python demo_flow.py --replay <FAILED_EXEC_ID>
 uv run kitaru executions input <EXEC_ID> --value true
-uv run kitaru memory list --scope <FLOW_ID> --scope-type flow
 ```
 
 ## Kitaru primitives used
@@ -655,7 +579,7 @@ uv run kitaru memory list --scope <FLOW_ID> --scope-type flow
 | `@checkpoint` | Replay-safe unit of work | `demo_flow.py` |
 | `wait()` | Human-in-the-loop gate | `demo_flow.py` |
 | `log()` | Structured metadata when supported by the log backend | `demo_flow.py` |
-| `memory.set/get` | Cross-execution durable state | `demo_flow.py` |
+| `save()` | Explicit artifact capture inside checkpoints | `demo_flow.py` |
 | `replay` | Re-execute from a checkpoint boundary | `demo_flow.py --replay` |
 
 ## Cleanup options
@@ -716,8 +640,8 @@ Never silently delete the demo directory or modify global MCP configuration.
 Enforce these rules throughout the entire session:
 
 1. **Template integrity**: Never alter the placement, arguments, or syntax
-   of `@flow`, `@checkpoint`, `wait()`, `log()`, `memory.*`, `save()`, or
-   `load()` decorators or calls. Only customize internal business logic and
+   of `@flow`, `@checkpoint`, `wait()`, `log()`, `save()`, or `load()`
+   decorators or calls. Only customize internal business logic and
    explanatory text. Preserve the template's `--replay` helper.
 
 2. **Scope limit**: Keep generated code under 150 lines. Use mock functions
@@ -740,12 +664,7 @@ Enforce these rules throughout the entire session:
 7. **No blanket shell approval**: Do not request broad shell preapproval from
    the user.
 
-8. **Memory placement**: `memory.*` calls belong in the flow body only,
-   never inside checkpoints. CLI/MCP memory inspection needs explicit typed
-   scopes; for this quickstart's flow memory, use `scope_type=flow` and the
-   `flow_id`, not the Python function name.
-
-9. **Real commands only**: Use only documented Kitaru CLI commands and this
+8. **Real commands only**: Use only documented Kitaru CLI commands and this
    quickstart's validated forms:
    - Install: `uv add 'kitaru[local,mcp]>=0.4.0'`
    - Local server/dashboard: `uv run kitaru login`, then open
@@ -756,17 +675,17 @@ Enforce these rules throughout the entire session:
    - There is no `kitaru ui`, `kitaru dashboard`, or top-level `kitaru run`
      command in this quickstart.
 
-10. **Logs expectations**: Do not promise that `kitaru executions logs` always
+9. **Logs expectations**: Do not promise that `kitaru executions logs` always
     returns rich structured logs. Empty or sparse logs on the default local
     setup are acceptable; use `executions get` and the dashboard as the
     reliable baseline.
 
-11. **MCP command shape**: Do not configure MCP with a bare `kitaru-mcp` in
+10. **MCP command shape**: Do not configure MCP with a bare `kitaru-mcp` in
     this quickstart. Use `command: "uv"` with
     `args: ["run", "--directory", "<ABSOLUTE_DEMO_DIR>", "kitaru-mcp"]`.
 
-12. **No API key requirements**: The quickstart must run without API keys,
+11. **No API key requirements**: The quickstart must run without API keys,
     cloud credentials, or external service accounts.
 
-13. **Checkpoint outputs must be serializable**: All mock return values from
+12. **Checkpoint outputs must be serializable**: All mock return values from
     checkpoints must be JSON-serializable: strings, numbers, lists, and dicts.

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -95,30 +95,12 @@ Once configured, the Kitaru MCP server exposes these tools:
 - `kitaru_executions_replay` — replay from a checkpoint
 - `kitaru_executions_cancel` — cancel a running execution
 - `get_execution_logs` — read execution logs when the active log backend has entries
-- `kitaru_memory_list` — list memory entries in a known typed scope
-- `kitaru_memory_get` — read a memory value from a known typed scope
-- `kitaru_memory_set` — write a memory value
-- `kitaru_memory_delete` — soft-delete a memory key
-- `kitaru_memory_history` — view version history for a key
-- `kitaru_memory_compact` — summarize memory values with an LLM
-- `kitaru_memory_purge` — physically delete old versions of one key
-- `kitaru_memory_purge_scope` — physically delete old versions across a scope
-- `kitaru_memory_compaction_log` — inspect compact/purge audit records
 - `kitaru_artifacts_list` — list artifacts for an execution
 - `kitaru_artifacts_get` — read an artifact
 - `kitaru_status` — check Kitaru connection status
 - `kitaru_stacks_list` — list available stacks
 - `manage_stack` — create or delete stacks
 
-Memory tools operate on explicit typed scopes: provide both `scope` and
-`scope_type` for scoped memory calls. `kitaru_memory_get` supports `version`,
-and `kitaru_memory_list` supports `prefix`. MCP can work with a known memory
-scope, but it does not currently expose memory scope listing or memory
-reindexing.
-
-For the quickstart's flow memory, use `scope_type="flow"` and the `flow_id`
-from `kitaru executions get <EXEC_ID> --output json`; do not assume the
-Python function name is the external memory scope.
 
 ## Authentication
 

--- a/skills/kitaru-quickstart/references/tracks/coding.py
+++ b/skills/kitaru-quickstart/references/tracks/coding.py
@@ -1,12 +1,12 @@
 """Coding agent flow — Kitaru quickstart demo.
 
-Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Demonstrates: @flow, @checkpoint, wait(), log(), save()
 Flow shape: analyze issue → generate patch → approve → apply patch
 """
 
 import time
 
-from kitaru import checkpoint, flow, log, memory, wait
+from kitaru import checkpoint, flow, log, save, wait
 
 
 @checkpoint
@@ -47,16 +47,14 @@ def apply_patch(patch: str) -> str:
     """Simulate applying the approved patch."""
     log(step="apply", patch_length=len(patch))
     time.sleep(1)
-    return f"Patch applied successfully ({len(patch)} chars)"
+    result = f"Patch applied successfully ({len(patch)} chars)"
+    save("patch_result", result, type="output")
+    return result
 
 
 @flow
 def coding_flow(issue: str) -> str:
     """Analyze an issue, generate a patch, review, and apply it."""
-    previous_issue = memory.get("last_issue")
-    if previous_issue:
-        log(returning_user=True, previous_issue=previous_issue)
-
     analysis = analyze_issue(issue)
     patch = generate_patch(analysis)
 
@@ -69,9 +67,7 @@ def coding_flow(issue: str) -> str:
     if not approved:
         return f"Patch for '{issue}' was rejected"
 
-    result = apply_patch(patch)
-    memory.set("last_issue", issue)
-    return result
+    return apply_patch(patch)
 
 
 REPLAY_FROM = "generate_patch"

--- a/skills/kitaru-quickstart/references/tracks/data.py
+++ b/skills/kitaru-quickstart/references/tracks/data.py
@@ -1,12 +1,12 @@
 """Data pipeline flow — Kitaru quickstart demo.
 
-Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Demonstrates: @flow, @checkpoint, wait(), log(), save()
 Flow shape: ingest → validate → transform → approve → load
 """
 
 import time
 
-from kitaru import checkpoint, flow, log, memory, wait
+from kitaru import checkpoint, flow, log, save, wait
 
 
 @checkpoint
@@ -59,16 +59,14 @@ def load_data(records: list[dict]) -> str:
     """Simulate loading transformed data into a destination."""
     log(step="load", record_count=len(records))
     time.sleep(1)
-    return f"Loaded {len(records)} records into warehouse"
+    result = f"Loaded {len(records)} records into warehouse"
+    save("load_result", result, type="output")
+    return result
 
 
 @flow
 def data_flow(source: str) -> str:
     """Ingest, validate, transform, approve, and load data."""
-    previous_source = memory.get("last_source")
-    if previous_source:
-        log(returning_user=True, previous_source=previous_source)
-
     raw = ingest(source)
     validation = validate(raw)
 
@@ -86,9 +84,7 @@ def data_flow(source: str) -> str:
     if not approved:
         return "Data load was rejected"
 
-    result = load_data(transformed)
-    memory.set("last_source", source)
-    return result
+    return load_data(transformed)
 
 
 REPLAY_FROM = "transform"

--- a/skills/kitaru-quickstart/references/tracks/research.py
+++ b/skills/kitaru-quickstart/references/tracks/research.py
@@ -1,12 +1,12 @@
 """Research/content approval flow — Kitaru quickstart demo.
 
-Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Demonstrates: @flow, @checkpoint, wait(), log(), save()
 Flow shape: gather sources → draft content → approve → publish
 """
 
 import time
 
-from kitaru import checkpoint, flow, log, memory, wait
+from kitaru import checkpoint, flow, log, save, wait
 
 
 @checkpoint
@@ -39,16 +39,14 @@ def publish(draft: str) -> str:
     """Simulate publishing the approved content."""
     log(step="publish", draft_length=len(draft))
     time.sleep(1)
-    return f"Published at https://example.com/articles/{abs(hash(draft)) % 10000}"
+    url = f"Published at https://example.com/articles/{abs(hash(draft)) % 10000}"
+    save("published_url", url, type="output")
+    return url
 
 
 @flow
 def research_flow(topic: str) -> str:
     """Research, draft, approve, and publish content about a topic."""
-    previous_topic = memory.get("last_topic")
-    if previous_topic:
-        log(returning_user=True, previous_topic=previous_topic)
-
     sources = gather_sources(topic)
     draft = draft_content(topic, sources)
 
@@ -61,9 +59,7 @@ def research_flow(topic: str) -> str:
     if not approved:
         return f"Draft about '{topic}' was rejected"
 
-    result = publish(draft)
-    memory.set("last_topic", topic)
-    return result
+    return publish(draft)
 
 
 REPLAY_FROM = "draft_content"

--- a/skills/kitaru-quickstart/references/tracks/support.py
+++ b/skills/kitaru-quickstart/references/tracks/support.py
@@ -1,12 +1,12 @@
 """Support/triage flow — Kitaru quickstart demo.
 
-Demonstrates: @flow, @checkpoint, wait(), log(), memory
+Demonstrates: @flow, @checkpoint, wait(), log(), save()
 Flow shape: classify ticket → draft response → approve → escalate
 """
 
 import time
 
-from kitaru import checkpoint, flow, log, memory, wait
+from kitaru import checkpoint, flow, log, save, wait
 
 
 @checkpoint
@@ -44,16 +44,14 @@ def escalate(ticket: str, response: str) -> str:
     """Simulate escalating the ticket with the approved response."""
     log(step="escalate", ticket=ticket, response_length=len(response))
     time.sleep(1)
-    return f"Ticket escalated to senior support. Response sent ({len(response)} chars)"
+    result = f"Ticket escalated to senior support. Response sent ({len(response)} chars)"
+    save("escalation_result", result, type="output")
+    return result
 
 
 @flow
 def support_flow(ticket: str) -> str:
     """Classify a ticket, draft a response, approve, and escalate."""
-    previous_ticket = memory.get("last_ticket")
-    if previous_ticket:
-        log(returning_user=True, previous_ticket=previous_ticket)
-
     classification = classify_ticket(ticket)
     response = draft_response(classification)
 
@@ -66,9 +64,7 @@ def support_flow(ticket: str) -> str:
     if not approved:
         return f"Escalation for '{ticket}' was rejected"
 
-    result = escalate(ticket, response)
-    memory.set("last_ticket", ticket)
-    return result
+    return escalate(ticket, response)
 
 
 REPLAY_FROM = "draft_response"

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -3,19 +3,18 @@ name: kitaru-scoping
 description: >-
   Scope and validate whether an agent workflow is well-suited for Kitaru's
   durable execution model, then design the flow architecture — checkpoint
-  boundaries, wait points, replay anchors, memory-vs-artifact strategy,
-  memory scope design, operator surface, and MVP scope. Runs a structured
-  interview to help users identify what benefits from durability, what doesn't,
-  what should live in memory versus artifacts, and where replay/resume
-  boundaries should go. Produces a flow_architecture.md specification document.
-  Use this skill whenever a user describes an agent workflow they want to make
-  durable, asks whether Kitaru is right for their use case, seems unsure about
-  where to place checkpoints or waits, needs to choose between SDK /
-  KitaruClient / CLI / MCP control surfaces, asks how to handle cross-execution
-  shared state, or arrives with a workflow that might be too simple or too
-  complex for Kitaru. Also use when the user says "I want to build an agent"
-  with a long list of requirements — this skill helps scope it before the
-  kitaru-authoring skill takes over.
+  boundaries, wait points, replay anchors, artifact strategy, operator surface,
+  and MVP scope. Runs a structured interview to help users identify what
+  benefits from durability, what doesn't, what should become explicit artifacts
+  or external state, and where replay/resume boundaries should go. Produces a
+  flow_architecture.md specification document. Use this skill whenever a user
+  describes an agent workflow they want to make durable, asks whether Kitaru is
+  right for their use case, seems unsure about where to place checkpoints or
+  waits, needs to choose between SDK / KitaruClient / CLI / MCP control
+  surfaces, asks how to handle state across executions, or arrives with a
+  workflow that might be too simple or too complex for Kitaru. Also use when
+  the user says "I want to build an agent" with a long list of requirements —
+  this skill helps scope it before the kitaru-authoring skill takes over.
 ---
 
 # Scope Kitaru Flow Architectures
@@ -29,14 +28,14 @@ flow architecture that the authoring skill can implement cleanly.
 Users often arrive in one of these states:
 
 - **The everything-flow**: one giant workflow that tries to mix planning,
-  execution, approvals, retries, side effects, durable state, and reporting
+  execution, approvals, retries, side effects, durable outputs, and reporting
   into a single tangled structure.
 - **The over-checkpointed design**: every tiny helper is a checkpoint, which
   adds serialization cost without adding replay value.
 - **The wrong tool problem**: the user needs streaming chat, sub-100ms serving,
   or a plain script rather than durable orchestration.
 - **The fuzzy durability problem**: the workflow might be a good Kitaru fit, but
-  nobody has decided where waits, replay anchors, memory boundaries, or side
+  nobody has decided where waits, replay anchors, artifact boundaries, or side
   effects should live.
 
 Your value is to turn that fog into a practical architecture.
@@ -47,26 +46,17 @@ Kitaru is a durable execution layer for Python workflows built around four
 user-facing surfaces:
 
 - **SDK primitives**: `@flow`, `@checkpoint`, `wait()`, `log()`, `save()`,
-  `load()`, `llm()`, `memory.configure()`, `memory.set()`, `memory.get()`,
-  `memory.list()`, `memory.history()`, `memory.delete()`, plus configuration
-  helpers (`configure`, `connect`, `create_stack`, `list_stacks`,
-  `current_stack`, `use_stack`, `delete_stack`)
-- **KitaruClient** (inspection/control plus explicit typed-scope
-  memory/artifact administration): `executions.get / list / latest / logs /
-  pending_waits / input / abort_wait / retry / resume / replay / cancel`,
-  `artifacts.list / get`, and `memories.get / list / history / set / delete /
-  scopes / compact / purge / purge_scope / compaction_log / reindex`
-- **CLI control**: `kitaru login`, `kitaru executions ...`,
-  `kitaru memory scopes/list/get/set/delete/history/compact/purge/purge-scope/
-  compaction-log/reindex`, stack/model/secret commands (including remote stack
-  creation for `kubernetes`, `vertex`, `sagemaker`, `azureml`), and runtime
-  inspection commands
+  `load()`, `llm()`, plus configuration helpers (`configure`, `connect`,
+  `create_stack`, `list_stacks`, `current_stack`, `use_stack`, `delete_stack`)
+- **KitaruClient** (inspection/control plus artifact inspection):
+  `executions.get / list / latest / logs / pending_waits / input / abort_wait /
+  retry / resume / replay / cancel` and `artifacts.list / get`
+- **CLI control**: `kitaru login`, `kitaru executions ...`, stack/model/secret
+  commands (including remote stack creation for `kubernetes`, `vertex`,
+  `sagemaker`, `azureml`), and runtime inspection commands
 - **MCP control**: execution tools (`kitaru_executions_list/get/latest/run/
-  input/retry/replay/cancel`), memory tools (`kitaru_memory_list/get/set/
-  delete/history/compact/purge/purge_scope/compaction_log`), artifact tools,
-  status, stack listing, and `manage_stack` (create/delete including remote
-  stacks). MCP memory can operate on a known typed scope, but cannot list memory
-  scopes or reindex historical memory tags.
+  input/retry/replay/cancel`), artifact tools, status, stack listing, and
+  `manage_stack` (create/delete including remote stacks).
 
 It also ships a **PydanticAI adapter** (`wrap(...)`, `hitl_tool(...)`) for agent
 workloads that want Kitaru tracking without rewriting the whole control flow.
@@ -97,8 +87,7 @@ Design operator workflows around `input` as the primary action, not `resume`.
 
 That means naming matters. Stable checkpoint names become the handles people use
 later for replay. Stable wait names become the handles for operational input.
-Stable memory typed scopes (`scope_type` + `scope`) and important keys become
-the handles people use to inspect or patch durable state later.
+Stable artifact names become handles people use to inspect outputs later.
 
 ### Surface ownership
 
@@ -108,8 +97,6 @@ Not every surface can do every job:
   MCP (`kitaru_executions_run`) — **not** `KitaruClient`, and not a top-level
   CLI `kitaru run` command
 - **Inspecting/controlling executions**: `KitaruClient`, CLI, MCP
-- **Using module-level memory inside flow code**: SDK `kitaru.memory`
-- **Explicit typed-scope memory administration**: `KitaruClient`, CLI, MCP
 - **Creating remote stacks**: CLI (`kitaru stack create`) and MCP
   (`manage_stack`) — the Python SDK `create_stack(...)` is **local stacks only**
 - **Artifact browsing**: `KitaruClient` and MCP — not the CLI
@@ -141,34 +128,28 @@ Listen for:
 - External systems: GitHub, email, databases, deployment targets, APIs
 - Data flow: what needs to persist between steps or executions
 - Failure points: where things break or must be resumed safely
-- Operator needs: who will inspect logs, replay work, submit wait input, seed
-  or edit durable state, or cancel runs later
+- Operator needs: who will inspect logs and artifacts, replay work, submit wait
+  input, or cancel runs later
 
 If the answer is thin, ask targeted follow-ups about side effects, human
-intervention, durable shared state, and failure recovery.
+intervention, durable outputs, and failure recovery.
 
-### Memory-oriented discovery questions
+### Durable state discovery questions
 
 Ask these when the workflow appears to need state beyond one execution:
 
-- What information must survive across executions?
-- Should that information be fetched by stable key, or is it really tied to one
-  execution output?
-- Who will seed or edit that state: flow code, admin scripts, a human operator,
-  or an MCP assistant?
-- Which typed scope owns each key: **namespace**, **flow**, or **execution**?
-- What exact `scope` value will operators use with that `scope_type`?
-- Does the workflow need replay-frozen values, or is "latest durable state"
-  acceptable?
-- Will the state need maintenance later: compaction, purge, purge-scope,
-  compaction-log inspection, or project-level reindexing?
-- If purge/purge-scope is needed, what retention rule applies: keep all history,
-  keep newest N, or include tombstoned keys?
-- If compact is needed, will the target environment have a default LLM model or
-  an explicit model configured?
+- Which values must be reproduced exactly during replay?
+- Which values are outputs of a specific run or checkpoint?
+- Which values are global application data that should live outside Kitaru?
+- Who will inspect or update those values later: flow code, admin scripts, a
+  human operator, or an MCP assistant?
+- Does a downstream flow need an upstream execution ID so it can load an
+  artifact from that run?
+- Is a database, object store, repository file, or service API the clearer home
+  for mutable shared data?
 
-These questions help you decide whether the design wants **memory** or
-**artifacts**.
+These questions help you decide which values should become **artifacts** and
+which should stay in an external system.
 
 ## Phase 2: Assess fit
 
@@ -181,14 +162,14 @@ Determine whether Kitaru is actually the right tool.
 - Human approval or correction points that must survive process restarts
 - Multi-step workflows that benefit from replay after a checkpoint
 - Operational debugging needs: logs, artifacts, execution history, audit trail
-- Durable shared state that should survive across executions under stable keys
+- Explicit outputs that should survive process restarts and be inspectable later
 
 ### Signals that Kitaru may be unnecessary
 
 - One-shot LLM calls with little cost and no replay value
 - Streaming chat UIs
 - Low-latency request/response serving
-- Simple automation scripts with no durable state
+- Simple automation scripts with no durable outputs
 - Continuous monitoring loops that should live in a service instead
 
 If the workflow is only a gray-area fit, say so plainly. Kitaru is valuable when
@@ -219,7 +200,6 @@ steps.
 - nested checkpoint calls
 - tiny internal model/tool calls inside a PydanticAI run that are already traced
   as child events
-- memory operations that belong in the flow body
 
 ### Real runtime constraints to respect
 
@@ -229,12 +209,6 @@ These are not style preferences. They are actual implementation boundaries.
 - Checkpoints do not nest.
 - `wait()` can only run in the flow body, never inside a checkpoint.
 - `save()` and `load()` require checkpoint scope.
-- `kitaru.memory.*` is allowed in flow scope, but forbidden inside a
-  checkpoint.
-- Outside a flow, module-level memory use requires configuring an active scope
-  first; `memory.configure(scope=...)` defaults to `scope_type="namespace"`.
-- Module-level memory uses the active configured typed scope; explicit `scope=`
-  and `scope_type=` live on client/CLI/MCP surfaces instead.
 - `log()` can run in flow scope or checkpoint scope.
 - `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
   synthetic `llm_call` checkpoint automatically.
@@ -258,54 +232,29 @@ Keep wait schemas simple and keep wait names stable. Those names become the
 handles operators use to provide input (via `client.executions.input(...)`,
 `kitaru executions input`, or MCP `kitaru_executions_input`).
 
-### Memory vs artifacts
+### State and artifact strategy
 
-This is one of the most important design choices.
+Use **artifacts** when a value is an execution output or replay/debug boundary
+that should stay tied to a specific run or checkpoint. Save those values inside
+checkpoints with `save(...)`, and inspect them later through KitaruClient or MCP
+artifact tools.
 
-Use **memory** when the workflow needs durable shared state addressed by stable
-`scope_type + scope + key` names.
-
-Use **artifacts** when the value is an execution output or replay/debug boundary
-that should stay tied to a specific run or checkpoint.
+Use an **external system** when the value is mutable application state shared
+across many executions, users, or services. Good homes include a database, an
+object store, a repository file, or an existing service API.
 
 A simple test:
 
-- If the workflow needs "the current repo style guide" or "the latest customer
-  preference", that smells like **memory**.
 - If the workflow needs "the exact draft produced in execution X" or "the exact
-  retrieval output from checkpoint Y", that smells like an **artifact**.
+  retrieval output from checkpoint Y", make it an **artifact**.
+- If the workflow needs "the current repo style guide" or "the latest customer
+  preference", put it in an **external system** and pass a stable reference into
+  the flow.
 
-Do not silently substitute memory for explicit checkpoint outputs. Memory is not
-a drop-in replacement for replay-stable artifacts.
+Do not silently substitute mutable external state for explicit checkpoint
+outputs. If replay must reproduce the exact value, make that value an artifact.
 
-### Memory scope design
-
-When memory is the right fit, choose the scope deliberately:
-
-- **namespace**: shared durable state across many executions, users, or agents
-- **flow**: state that naturally belongs to one flow identity. Operator
-  surfaces may expose this as a flow ID, so capture the exact scope value from
-  execution details or memory-scope discovery.
-- **execution**: state isolated to one run but still key-addressable
-
-Important asymmetry to remember:
-
-- Module-level `kitaru.memory` uses an **active typed scope** set by
-  `memory.configure(...)` or inferred from the active flow
-- `KitaruClient.memories`, CLI memory commands, and MCP memory tools use
-  **explicit typed scope** (`scope_type` + `scope`) on each scoped operation
-- CLI scoped memory commands require both `--scope` and `--scope-type`
-- MCP can read/write/compact/purge a known typed scope, but cannot list memory
-  scopes or run reindex; do not choose MCP as the only operator surface if the
-  operator must discover scopes
-
-For execution-scoped memory, distinguish membership from producer provenance: a
-detached admin write can target `scope_type="execution"` plus
-`scope=<execution_id>` after a run finishes, so it belongs to that execution
-bucket even if that memory version was not produced during the live flow.
-
-Stable typed scope names become operator handles just like checkpoint and wait
-names become operator handles.
+Stable checkpoint, wait, and artifact names become operator handles.
 
 ### Side effects
 
@@ -334,20 +283,13 @@ Ask which surface will be used for each job:
 - replay from a checkpoint
 - cancel a stuck run
 - inspect artifacts
-- seed memory
-- inspect or edit memory
-- list memory scopes
-- read memory versions or prefix-filter memory lists
-- compact, purge, inspect compaction logs, or reindex memory
 - create/manage stacks
 
 Use these rules:
 
 - **SDK flow objects** for launching new executions from Python code
-- **SDK `kitaru.memory`** for in-flow memory usage and outside-flow scripts that
-  can work with one active configured typed scope
 - **KitaruClient** for programmatic inspection and control of existing
-  executions, plus explicit typed-scope memory administration
+  executions and artifacts
 - **CLI** for human operators and shell-based workflows; also the only way to
   log in with managed workspace names/IDs
 - **MCP** for agent tools and LLM-assisted operations
@@ -367,30 +309,6 @@ Important asymmetries to account for in the design:
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
 
-### Memory-specific asymmetries
-
-| Memory capability | SDK `kitaru.memory` | KitaruClient | CLI | MCP |
-|---|---|---|---|---|
-| In-flow memory reads/writes | Yes | No | No | No |
-| Outside-flow seed/update | Yes, after `configure(...)` | Yes | Yes | Yes |
-| Active-scope Python API | Yes | No | No | No |
-| Explicit typed-scope operations | No | Yes | Yes | Yes |
-| List memory scopes | No | Yes | Yes | No |
-| Versioned reads | Yes | Yes | No | Yes |
-| Prefix listing | No | Yes | No | Yes |
-| Compact / purge / compaction log | No | Yes | Yes | Yes |
-| Reindex historical tags | No | Yes | Yes | No |
-
-Memory maintenance has different jobs:
-
-- `compact` sends selected memory values to an LLM and writes a summary as a new
-  memory version. It does not delete source entries.
-- `purge` / `purge_scope` physically delete old versions. `keep=1` keeps the
-  newest selected version; omitting `keep` deletes all selected versions.
-- `compaction_log` reads the audit trail for compact and purge operations.
-- `reindex` is project-scoped, dry-run by default, additive tag backfill for
-  historical memory discovery. It is not cleanup and does not rewrite values.
-
 ## Phase 5: Replay strategy
 
 Ask explicitly: "If this workflow fails or the requirements change, where would
@@ -409,17 +327,12 @@ Then design replay anchors deliberately.
   `input`, not via override keys
 - Duplicate or vague names make replay painful later
 
-### Memory replay caveat
+### External state replay caveat
 
-Memory is durable, but it is not fully replay-frozen in the current release.
-
-That means:
-
-- replayed reads may observe newer memory values than the source execution saw
-- replayed writes create new memory versions
-
-If the user needs frozen replay semantics for a critical input, keep that input
-as an explicit checkpoint output/artifact instead of shared memory.
+Mutable data outside Kitaru is not replay-frozen by Kitaru. If a replay reads
+"latest" data from a database or service, it may see a newer value than the
+source execution saw. If that would be unsafe, capture the exact value as a
+checkpoint output or saved artifact first.
 
 When scoping, write down which checkpoint names are intended to be stable public
 replay selectors.
@@ -451,26 +364,9 @@ Review the proposed design for these smells:
 - too many tiny checkpoints
 - waits buried inside logic that belongs in the flow body
 - nested checkpoints or attempts to call flows from flows
-- memory operations planned inside checkpoints
-- memory used where replay-frozen artifacts are required
-- module-level memory designs that assume per-call `scope=`
-- CLI or MCP operator plans that assume default memory scope inference
-- memory scopes named without a `scope_type`
-- choosing CLI as the only memory inspection surface when versioned reads or
-  prefix filtering are required
-- choosing MCP as the memory operator surface without providing exact
-  `scope_type` + `scope` values
-- assuming MCP can list memory scopes or run reindex
-- designing memory maintenance but assigning it to module-level `kitaru.memory`
-- treating `compact` as cleanup instead of summary-writing; purge is the
-  separate hard-delete step
-- treating `delete` and `purge` as interchangeable cleanup operations
-- forgetting that `memory reindex` is project-scoped, additive tag backfill, not
-  a value rewrite or cleanup operation
 - side effects mixed into planning checkpoints
 - artifact sharing with no naming strategy
 - replay needs discussed abstractly but no concrete checkpoint names chosen
-- memory scopes or keys left vague even though operators must inspect them later
 - assuming CLI, client, and MCP all expose the same controls
 - using `KitaruClient` to launch executions (it can't — use flow objects)
 - using SDK `create_stack(...)` for remote stacks (it's local-only)
@@ -488,7 +384,8 @@ The MVP should usually have:
 - 2-4 checkpoints
 - at most one wait unless human review is the core product
 - one clear operator surface for the main operational tasks
-- a deliberate memory decision (yes/no, and why)
+- a deliberate state persistence decision (artifacts, external system, or
+  neither)
 - a small set of stable replay anchors (checkpoint names)
 - output that is genuinely useful on its own
 
@@ -525,28 +422,15 @@ guide.
 - **Resume**: [KitaruClient | CLI] (not MCP)
 - **Replay / cancel**: [surface]
 - **Artifact inspection**: [KitaruClient | MCP] (not CLI)
-- **Memory seed/update**: [SDK module API | KitaruClient | CLI | MCP]
-- **Memory inspection**: [KitaruClient | CLI | MCP]
-- **Memory scope listing**: [KitaruClient | CLI] (not MCP)
-- **Memory maintenance**: [KitaruClient | CLI | MCP for compact/purge/log;
-  KitaruClient | CLI for reindex]
 - **Stack management**: [SDK (local only) | CLI (local + remote) | MCP (local + remote)]
 
-## Memory Strategy
-- **Use memory?**: [yes/no]
-- **Why memory vs artifacts?**: [brief reasoning]
-- **Typed scopes**: [`scope_type` + `scope` -> owner/operator surface]
-- **Keys**: [stable keys and what they store]
-- **Seed/update surfaces**: [module API | KitaruClient | CLI | MCP]
-- **Maintenance**: [none | compact | purge | purge-scope | compaction-log |
-  reindex; who runs it]
-- **Retention policy**: [keep all history | keep newest N | purge tombstoned
-  keys | other]
-- **Inspection constraints**: [scope listing? versioned read? prefix list?
-  chosen surface]
-- **MCP scope handoff**: [if MCP is used, where exact `scope_type` + `scope`
-  values come from]
-- **Replay caveat**: [if relevant]
+## State and Artifact Strategy
+- **Execution-linked values**: [what should be saved as artifacts]
+- **External state**: [database/object store/repository file/service API, if any]
+- **Why this split**: [brief reasoning]
+- **Artifact names**: [stable names and what they store]
+- **Inspection surfaces**: [KitaruClient | MCP | dashboard]
+- **Replay caveat**: [if external mutable state is read]
 
 ## Flow Design
 
@@ -569,12 +453,11 @@ guide.
 ## Cross-Flow Data
 [If multiple flows exist, explain what artifacts are shared, who consumes them,
 and how downstream flows obtain upstream execution IDs for `load(...)` calls. If
-memory is shared across flows, name the scopes and key owners explicitly.]
+external state is shared across flows, name the owning system and update path explicitly.]
 
 ## Naming Strategy
 - **Stable checkpoint names** (replay anchors): [...]
 - **Stable wait names** (operator input handles): [...]
-- **Stable memory scopes / keys**: [...]
 - **Artifact naming rules**: [...]
 
 ## Deferred / Future Work
@@ -591,7 +474,7 @@ Once the document is ready:
 1. Show it to the user and ask what should change
 2. Offer the next step: implement the MVP flow with `kitaru-authoring`
 3. Carry forward the chosen checkpoint names, wait names, replay anchors,
-   memory decisions, memory scopes, and operator surfaces into implementation
+   state persistence decisions, artifact names, and operator surfaces into implementation
 
 ## Readiness check
 


### PR DESCRIPTION
## What changed

- Removed all Kitaru-native memory references from the packaged skills and repo guidance.
- Reframed the quickstart, scoping, and authoring guidance around the current Kitaru surfaces: durable execution, checkpoints, waits, logs, saved artifacts, execution inspection, CLI/MCP tools, and `KitaruClient`.
- Updated the quickstart demo templates to use `save(...)` artifact capture instead of removed memory imports/calls.
- Removed memory MCP tool documentation from the manual MCP setup guide.
- Bumped plugin metadata from `0.4.1` to `0.4.2`.
- Fixed the manual installation instructions so they install all three skills, including quickstart references.

## Why

Kitaru native memory has been removed from the main Kitaru SDK. These skills are agent-facing teaching material, so leaving `kitaru.memory`, `kitaru memory`, `KitaruClient.memories`, or `kitaru_memory_*` guidance here would cause agents to generate code against APIs that no longer exist.

## Reviewer Notes

Please especially check:

- `skills/kitaru-authoring/SKILL.md` — the biggest cleanup; it should now teach artifacts/logs/execution inspection rather than native key-value memory.
- `skills/kitaru-scoping/SKILL.md` — persistence decisions should point to artifacts or external/user-owned systems, not Kitaru memory.
- `skills/kitaru-quickstart/references/tracks/*.py` — templates now import `save` and store final outputs as artifacts.
- `skills/kitaru-quickstart/references/mcp-config-guide.md` — removed memory MCP tools while preserving execution/artifact tools.

Useful checks:

```bash
rg -n -i 'kitaru\.memory|KitaruClient\.memories|kitaru memory|kitaru_memory_|memory\.configure|memory\.get|memory\.set|memory\.list|memory\.history|memory\.delete' .
rg -n -i 'memory' .
jq . .claude-plugin/plugin.json .claude-plugin/marketplace.json
uv run python -m py_compile skills/kitaru-quickstart/references/tracks/*.py
```

## Verification

- `rg -n -i 'kitaru\.memory|KitaruClient\.memories|kitaru memory|kitaru_memory_|memory\.configure|memory\.get|memory\.set|memory\.list|memory\.history|memory\.delete' .` — no output
- `rg -n -i 'memory' .` — no output
- `jq . .claude-plugin/plugin.json .claude-plugin/marketplace.json` — passed
- `uv run python -m py_compile skills/kitaru-quickstart/references/tracks/*.py` — passed
- Markdown fence balance check — passed
- Post-review follow-up commit added for README/manual-install and quickstart handoff consistency


