### PR TITLE
Update skills for Kitaru 0.12

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
     "url": "https://zenml.io"
   },
   "metadata": {
-    "description": "Skills for designing and building durable AI agent workflows with Kitaru",
-    "version": "0.4.2",
+    "description": "Three Kitaru skills for quickstart onboarding, durable flow scoping, and authoring with current adapter families",
+    "version": "0.5.0",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
   },
@@ -15,8 +15,8 @@
     {
       "name": "kitaru",
       "source": "./",
-      "description": "Bundles three Kitaru skills: kitaru-quickstart (interactive onboarding with crash-recovery, wait(), and artifact/log inspection demos), kitaru-scoping (validates Kitaru fit and outputs a flow_architecture.md), and kitaru-authoring (reference for flows, checkpoints, waits, KitaruClient, CLI, MCP, and PydanticAI integration).",
-      "version": "0.4.2",
+      "description": "Bundles three Kitaru skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), and kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK).",
+      "version": "0.5.0",
       "author": {
         "name": "ZenML",
         "url": "https://kitaru.ai"
@@ -33,7 +33,12 @@
         "agent-workflows",
         "checkpoints",
         "human-in-the-loop",
-        "pydantic-ai"
+        "pydantic-ai",
+        "openai-agents",
+        "langgraph",
+        "claude-agent-sdk",
+        "mcp",
+        "deployments"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
-  "description": "Kitaru skills for Claude Code: quickstart (interactive onboarding), scoping (flow architecture design), and authoring (writing durable agent workflows)",
-  "version": "0.4.2",
+  "description": "Kitaru skills for Claude Code: quickstart onboarding, scoping durable flow architecture, and authoring with current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK)",
+  "version": "0.5.0",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"
@@ -9,5 +9,17 @@
   "homepage": "https://kitaru.ai",
   "repository": "https://github.com/zenml-io/kitaru-skills",
   "license": "Apache-2.0",
-  "keywords": ["kitaru", "zenml", "durable-execution", "ai-agents", "workflows"]
+  "keywords": [
+    "kitaru",
+    "zenml",
+    "durable-execution",
+    "ai-agents",
+    "workflows",
+    "checkpoints",
+    "human-in-the-loop",
+    "pydantic-ai",
+    "openai-agents",
+    "langgraph",
+    "claude-agent-sdk"
+  ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ There is no build step in this repo. Most contributor work is editing Markdown a
 - `git diff --stat` gives a compact review of changed files.
 - `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
 
-For manual smoke testing, follow the install commands in [`README.md`](README.md) and verify the plugin exposes `/kitaru-scoping` and `/kitaru-authoring`.
+For manual smoke testing, follow the install commands in [`README.md`](README.md) and verify the plugin exposes `/kitaru-quickstart`, `/kitaru-scoping`, and `/kitaru-authoring`.
 
 ## Coding Style & Naming Conventions
 Use Markdown for prose and JSON for plugin metadata. Match the existing style:
@@ -37,6 +37,27 @@ There is currently no dedicated automated test suite. Treat testing as documenta
 - Check that examples match the current Kitaru API surface.
 - Confirm new trigger phrases and command names are consistent across `SKILL.md`, `README.md`, and plugin metadata.
 - Re-read edited Markdown in rendered form when possible to catch broken lists, code fences, or tables.
+- Validate `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` with `jq .` or equivalent.
+- Run a memory-regression search for removed native memory terms before finishing.
+
+## Release Sync Checklist
+
+When updating the plugin for a new Kitaru release, verify current source of truth
+before editing skill prose:
+
+- Adapter exports under `kitaru/src/kitaru/adapters/*/__init__.py`
+- Current adapter guides for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK
+- MCP server docs for current tool names and categories
+- `CHANGELOG.md` and `pyproject.toml` for release facts and removed APIs
+- Skill inventory and slash command names across README, AGENTS, CLAUDE, metadata, and frontmatter
+- All three plugin metadata version fields: `.claude-plugin/plugin.json` `version`, `.claude-plugin/marketplace.json` `metadata.version`, and `.claude-plugin/marketplace.json` `plugins[0].version`
+- Markdown validity: headings, tables, code fences, and beginner quickstart pacing
+
+Native Kitaru memory was removed in Kitaru 0.11.0. Do not reintroduce
+`kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, MCP
+`kitaru_memory_*`, or old wording that recommends a native durable memory API.
+Cross-execution application state belongs in an external/application-owned
+store, with explicit values or stable references passed into flows.
 
 ## Commit & Pull Request Guidelines
 Recent history uses short, imperative commit messages such as `Update quickstart flow templates` and `Align skills with current Kitaru SDK surface`. Follow that pattern.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,9 @@ before editing skill prose:
 - All three plugin metadata version fields: `.claude-plugin/plugin.json` `version`, `.claude-plugin/marketplace.json` `metadata.version`, and `.claude-plugin/marketplace.json` `plugins[0].version`
 - Markdown validity: headings, tables, code fences, and beginner quickstart pacing
 
-Native Kitaru memory was removed in Kitaru 0.11.0. Do not reintroduce
-`kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, MCP
-`kitaru_memory_*`, or old wording that recommends a native durable memory API.
-Cross-execution application state belongs in an external/application-owned
+Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce
+old native-memory wording or recommend a Kitaru-owned durable key-value state
+API. Cross-execution application state belongs in an external/application-owned
 store, with explicit values or stable references passed into flows.
 
 ## Commit & Pull Request Guidelines

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ There is no build step, no linter, no test suite. The deliverables are the three
 - All three skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the others.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
 - The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
-- Native Kitaru memory was removed in Kitaru 0.11.0. Do not reintroduce `kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, MCP `kitaru_memory_*`, or durable-shared-memory wording as a recommended Kitaru API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
+- Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce old native-memory wording or recommend a Kitaru-owned durable key-value state API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
 - Plugin version is in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — bump all version fields consistently when publishing updates.
 
 ## Installation methods (for testing)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-This is a **Claude Code skills plugin** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows. It contains no application code; the deliverables are two Markdown skill files that teach Claude Code how to scope and author Kitaru workflows.
+This is a **Claude Code skills plugin** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows. It contains no application code; the deliverables are three Markdown skill files plus quickstart references that teach Claude Code how to onboard, scope, and author Kitaru workflows.
 
 The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-skills`.
 
@@ -23,7 +23,7 @@ skills/
 
 - **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
 - **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
-- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, and PydanticAI adapter integrations.
+- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, deployments, secrets, and current adapter integrations: PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK.
 
 The intended user workflow is: quickstart → scope → author.
 
@@ -32,7 +32,7 @@ The intended user workflow is: quickstart → scope → author.
 There is no build step, no linter, no test suite. The deliverables are the three `SKILL.md` files plus the quickstart reference templates and setup guides. Quality comes from:
 
 1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
-2. **Completeness of asymmetry tables** — the skills document capability differences across four surfaces (SDK, KitaruClient, CLI, MCP). These tables must stay synchronized between the two skill files.
+2. **Completeness of asymmetry tables** — the skills document capability differences across SDK, KitaruClient, CLI, MCP, deployments, secrets, and adapter surfaces. These tables must stay synchronized between the scoping and authoring skills.
 3. **Stable naming** — checkpoint names, wait names, artifact names, and operator handles are first-class concepts. Changes to naming conventions in the skills ripple into generated architecture documents.
 
 ## Key constraints when editing skills
@@ -41,7 +41,8 @@ There is no build step, no linter, no test suite. The deliverables are the three
 - All three skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored in the others.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
 - The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
-- Plugin version is in `.claude-plugin/plugin.json` — bump it when publishing updates.
+- Native Kitaru memory was removed in Kitaru 0.11.0. Do not reintroduce `kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, MCP `kitaru_memory_*`, or durable-shared-memory wording as a recommended Kitaru API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
+- Plugin version is in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — bump all version fields consistently when publishing updates.
 
 ## Installation methods (for testing)
 
@@ -51,8 +52,8 @@ There is no build step, no linter, no test suite. The deliverables are the three
 /plugin install kitaru@kitaru
 
 # Manual (for local development)
-mkdir -p .claude/skills/kitaru-quickstart .claude/skills/kitaru-scoping .claude/skills/kitaru-authoring
-cp -r skills/kitaru-quickstart/ .claude/skills/kitaru-quickstart/
-cp skills/kitaru-scoping/SKILL.md .claude/skills/kitaru-scoping/SKILL.md
-cp skills/kitaru-authoring/SKILL.md .claude/skills/kitaru-authoring/SKILL.md
+mkdir -p .claude/skills
+cp -R skills/kitaru-quickstart .claude/skills/
+cp -R skills/kitaru-scoping .claude/skills/
+cp -R skills/kitaru-authoring .claude/skills/
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ discovering, designing, and building durable AI agent workflows with
 |---|---|---|
 | **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
 | **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
-| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, CLI commands, MCP tools, and PydanticAI adapter integrations |
+| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK |
 
 ### Recommended workflow
 
@@ -31,8 +31,8 @@ discovering, designing, and building durable AI agent workflows with
 ```
 
 Once installed, Claude Code will automatically use the skills based on context.
-You can also invoke them explicitly with `/kitaru-scoping` or
-`/kitaru-authoring`.
+You can also invoke them explicitly with `/kitaru-quickstart`,
+`/kitaru-scoping`, or `/kitaru-authoring`.
 
 ### Team installation
 
@@ -80,12 +80,15 @@ rm -rf "$tmpdir"
 - "Add a flow-level `kitaru.wait()` approval gate before publish."
 - "Add explicit artifact saving to this flow."
 - "How do I inspect executions, waits, logs, and artifacts from the CLI or MCP?"
-- "Wrap this PydanticAI call in a `@checkpoint` and preserve replay safety."
+- "Convert this PydanticAI agent to `KitaruAgent` and preserve replay safety."
+- "Use `KitaruRunner` for this OpenAI Agents workflow and choose the checkpoint strategy."
+- "Help me add Kitaru durability around a LangGraph graph."
+- "Make this Claude Agent SDK invocation durable without promising granular tool replay."
 
 ## Links
 
 - [Kitaru documentation](https://kitaru.ai/docs)
-- [Claude Code Skills docs](https://kitaru.ai/docs/agent-integrations/claude-code-skill)
+- [Claude Code Skills docs](https://kitaru.ai/docs/agent-native/claude-code-skill)
 - [Kitaru SDK repository](https://github.com/zenml-io/kitaru)
 
 ## License

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -4,17 +4,22 @@ description: >
   Guide for writing Kitaru durable workflows and operational control paths. Use
   when creating or refactoring Kitaru flows, checkpoints, waits, logging,
   artifacts, tracked LLM calls, replay/resume/retry flows, KitaruClient usage,
-  CLI commands, MCP operations, or PydanticAI adapter integrations. Triggers on
+  CLI commands, MCP operations, deployments, secrets, or adapter integrations
+  for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK. Triggers on
   mentions of kitaru, @flow, @checkpoint, kitaru.wait, kitaru.log,
   kitaru.save, kitaru.load, KitaruClient, replay, resume, retry,
-  `kitaru executions ...`, MCP tools, `wrap(...)`, or `hitl_tool(...)`.
+  `kitaru executions ...`, MCP tools, `KitaruAgent`, `KitaruRunner`,
+  `KitaruGraphRunner`, `KitaruClaudeRunner`, `wait_for_input`,
+  `wait_for_approval`, `wait_for_interrupt`, or migration from deprecated
+  `wrap(...)`.
 ---
 
 # Kitaru Authoring Skill
 
 Use this guide when writing or refactoring Kitaru workflows and when choosing
-which Kitaru surface to use for running, observing, replaying, controlling, or
-inspecting durable state for those workflows.
+which Kitaru surface to use for running, observing, replaying, controlling,
+deploying, or inspecting durable artifacts and external state references for
+those workflows.
 
 > **Before building**: If the workflow shape is still fuzzy, suggest the
 > `kitaru-scoping` skill first. It helps the user decide whether Kitaru is a
@@ -77,6 +82,9 @@ Enforce these rules when writing or reviewing Kitaru code:
    synthetic `llm_call` checkpoint automatically.
 9. Use stable, unique names for checkpoints, waits, and artifacts so replay and
    operations stay unambiguous.
+10. Do not reintroduce removed native-memory APIs. Use artifacts for
+    execution-linked values and external/application-owned stores for mutable
+    cross-execution state.
 
 ## Primitive reference
 
@@ -88,12 +96,15 @@ Use `@flow` for the durable orchestration boundary.
 - Main entrypoints:
   - `.run(...)` — pass `stack="..."` to target a remote stack
   - `.replay(exec_id, from_=..., overrides=..., **flow_inputs)`
+- Use `current_execution_id()` inside a running flow/checkpoint when code needs
+  to record or pass along the active execution ID. It returns `None` outside a
+  Kitaru execution.
 
 ### `@checkpoint`
 
 Use `@checkpoint` for meaningful replayable units of work.
 
-- Supported decorator args: `retries`, `type`
+- Supported decorator args: `retries`, `type`, `cache`
 - Supported call styles:
   - direct call inside a flow
   - `.submit(...)`
@@ -152,9 +163,11 @@ one of these explicit patterns instead:
   arbitrary workflow state.
 
 Do not invent SDK helpers, CLI commands, or MCP tools for removed native
-key-value state. When replay correctness matters, make the critical value an
-explicit checkpoint output or saved artifact so the exact value from the source
-execution remains inspectable.
+key-value state. Specifically, do not recommend `kitaru.memory`,
+`KitaruClient.memories`, `kitaru memory`, or MCP `kitaru_memory_*` tools. When
+replay correctness matters, make the critical value an explicit checkpoint
+output or saved artifact so the exact value from the source execution remains
+inspectable.
 
 ### `llm(...)`
 
@@ -224,6 +237,10 @@ in every interface.
 - Use `configure(...)`, `connect(server_url, ...)`, `list_stacks()`,
   `current_stack()`, `use_stack()`, `create_stack(...)` (**local stacks only**),
   `delete_stack(...)`
+- Use `create_secret(...)`, `delete_secret(...)`, and `get_secret(...)` for
+  Kitaru-native secret writes/reads
+- Use `current_execution_id()` inside active runs when code needs the execution
+  ID for downstream references
 - Launch executions: `flow.run(...)`, `flow.replay(...)`
 
 ### KitaruClient (execution control + artifact inspection)
@@ -234,10 +251,15 @@ inspection**, not for launching new executions.
 - `executions.get / list / latest / logs / pending_waits / input / abort_wait /
   retry / resume / replay / cancel`
 - `artifacts.list / get`
+- Deployment inspection/invocation helpers where supported by the active server
+- Auth management namespaces for service accounts and API keys
 
 ### CLI
 
-- `login`, `logout`, `status`, `info`
+- `login`, `logout`, `status`, `info` (`--all`, `--file`, JSON/YAML export)
+- `clean project / global / all` for safe local-state reset (`--dry-run` first)
+- `analytics opt-in / opt-out / status`
+- `auth token` for a short-lived bearer token from the active connection
 - `log-store set / show / reset`
 - `stack list / current / show / use / create / delete`
   - `stack create` supports `local`, `kubernetes`, `vertex`, `sagemaker`,
@@ -247,7 +269,10 @@ inspection**, not for launching new executions.
     provisioning
 - `model register / list`
 - `secrets set / show / list / delete`
+- `build`, `deploy`, `invoke`, and `flow deployments list/get/delete/tag/untag/logs/curl`
 - `executions get / list / logs / input / replay / retry / resume / cancel`
+- List commands use `--page` / `--size` pagination where documented; `--limit`
+  is a first-page shortcut for compatible lists
 - JSON output contract: `--output json` / `-o json` emits
   `{command, item}` for single-item commands, `{command, items, count}` for
   lists, and JSONL event objects for `executions logs --follow --output json`
@@ -255,12 +280,18 @@ inspection**, not for launching new executions.
 ### MCP tools (exact names)
 
 - `kitaru_executions_list`, `kitaru_executions_get`, `kitaru_executions_latest`
+- `get_execution_logs`
 - `kitaru_executions_run` (target format: `<module_or_file>:<flow_name>`)
 - `kitaru_executions_input`, `kitaru_executions_retry`,
   `kitaru_executions_replay`, `kitaru_executions_cancel`
-- `get_execution_logs`
+- `kitaru_deployments_deploy`, `kitaru_deployments_invoke`,
+  `kitaru_deployments_list`, `kitaru_deployments_get`,
+  `kitaru_deployments_delete`, `kitaru_deployments_tag`,
+  `kitaru_deployments_untag`
 - `kitaru_artifacts_list`, `kitaru_artifacts_get`
-- `kitaru_status`, `kitaru_stacks_list`
+- `kitaru_secrets_create` (metadata-only secret creation; no MCP delete tool)
+- `kitaru_start_local_server`, `kitaru_stop_local_server`, `kitaru_status`,
+  `kitaru_stacks_list`
 - `manage_stack` (create/delete; supports `local`, `kubernetes`, `vertex`,
   `sagemaker`, `azureml`, plus `extra` and `async_mode`)
 
@@ -279,6 +310,12 @@ inspection**, not for launching new executions.
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
 | Switch active stack | Yes | No | Yes | No |
+| Deploy flow version | No (use CLI/server APIs) | Limited deployment namespace | Yes | Yes |
+| Invoke deployment | No (use deployment endpoint/client) | Yes | Yes | Yes |
+| Create secret | Yes | No | Yes | Yes (metadata only) |
+| Delete secret | Yes | No | Yes | No |
+| Print auth token / curl command | No | No | Yes | No |
+| Clean/reset local state | No | No | Yes | No |
 
 ## Connection and runtime context
 
@@ -297,56 +334,129 @@ Use Kitaru configuration helpers instead of inventing custom runtime wiring.
   registries are transported into submitted/replayed runs via
   `KITARU_MODEL_REGISTRY`
 - `secrets set / show / list / delete` manage secret values used by aliases
+- `create_secret(...)` / `delete_secret(...)` are the Python SDK write helpers;
+  `kitaru_secrets_create` is the MCP metadata-only create path
+- `kitaru auth token` prints a short-lived bearer token for raw HTTP calls
+- `kitaru flow deployments curl FLOW` generates a copy-pasteable curl command
+  that starts a deployment execution without inlining real token values
 
-## PydanticAI adapter
+## Adapter reference
 
-Public adapter surface:
+Use adapters when the agent framework already owns an inner runtime. Kitaru then
+needs a clear seam where it can put durable checkpoints without pretending to
+control side effects it cannot see.
 
-- `kitaru.adapters.pydantic_ai.wrap(agent, *, name=None,
-  tool_capture_config=None, tool_capture_config_by_name=None)`
-- `kitaru.adapters.pydantic_ai.hitl_tool(*, question=None, name=None,
-  schema=bool)`
+### PydanticAI / `KitaruAgent`
 
-What the adapter really does:
+Public surface to reach for in new code:
 
-- Wrapped agents must already have a model bound at construction time
-- Wraps agent/model/tool activity so it is tracked under Kitaru execution
-  metadata
-- Inside a checkpoint, child model/tool events become part of that checkpoint's
-  trace
-- At flow scope outside a checkpoint, `run()` and `run_sync()` use a synthetic
-  `llm_call` checkpoint
-- `hitl_tool(...)` is a tool marker/decorator that bridges tool-time approvals
-  back to flow-level `wait(...)` — it is not the wait primitive itself
-- Tool capture modes are `full`, `metadata_only`, and `off`
-- Per-tool capture overrides are supported
-- MCP toolsets are supported and wrapped (via `KitaruMCPToolset`)
-- Deferred tool flows (`ApprovalRequired`, `CallDeferred`) are not supported;
-  prefer `hitl_tool(...)` or an explicit flow-level `wait(...)` instead
-- Only `run()` and `run_sync()` are explicitly synthetic-checkpointed at flow
-  scope; do not assume `iter()` behaves identically
+- `KitaruAgent(agent, *, name=None, capture=CapturePolicy(...), granular_checkpoints=True, ...)`
+- `CapturePolicy(tool_capture="full" | "metadata" | None, tool_capture_overrides={...})`
+- `wait_for_input(...)` and `hitl_tool(...)` for human input from tool context
+- `KitaruToolset`, `KitaruFunctionToolset`, `KitaruMCPServer`,
+  `kitaruify_toolset(...)`, and `kitaruify_mcp_server(...)` for lower-level
+  durable tool surfaces
 
-Safe default pattern: wrap the agent once at module scope, then call it inside
-an explicit outer checkpoint with `type="llm_call"`. This gives you the clearest
-replay boundary.
+`wrap(...)` is still exported only as a deprecated compatibility shim. Do not
+show it as the normal path for new code.
+
+Key implementation rules:
+
+- The wrapped PydanticAI agent must have a concrete model at construction time.
+- Default granular mode creates separate model/tool/MCP checkpoints.
+- `granular_checkpoints=False` switches to one turn checkpoint per agent run.
+- Inside your own `@checkpoint`, `KitaruAgent` runs as a passthrough so the
+  explicit checkpoint is the replay boundary.
+- `wait_for_input(...)` is a wrapper around `kitaru.wait(...)`; it still has to
+  create the wait at flow scope. In granular mode, opt regular waiting tools out
+  with `tool_checkpoint_config_by_name={"tool_name": False}` or use
+  `@hitl_tool` for pure wait tools.
+- Capture policy is observability-only. Current tool capture values are
+  `"full"`, `"metadata"`, or `None`.
+- `run_stream()` and `iter()` return context managers and need explicit
+  checkpointing; streamed turns can fall back from granular to turn behavior.
+
+Safe default pattern for explicit flows:
 
 ```python
-from kitaru import checkpoint, flow
-from kitaru.adapters import pydantic_ai as kp
+import kitaru
+from pydantic_ai import Agent
+from kitaru.adapters.pydantic_ai import CapturePolicy, KitaruAgent
 
-agent = kp.wrap(
-    Agent(model, tools=[...]),
-    tool_capture_config={"mode": "full"},
+agent = Agent("openai:gpt-4o", name="researcher")
+durable_agent = KitaruAgent(
+    agent,
+    capture=CapturePolicy(tool_capture="full"),
 )
 
-@checkpoint(type="llm_call")
+@kitaru.checkpoint
 def run_agent(prompt: str) -> str:
-    return agent.run_sync(prompt).output
+    return durable_agent.run_sync(prompt).output
 
-@flow
+@kitaru.flow
 def my_flow(topic: str) -> str:
     return run_agent(f"Research {topic}")
 ```
+
+### OpenAI Agents / `KitaruRunner`
+
+Use `KitaruRunner` for OpenAI Agents SDK agents.
+
+- `checkpoint_strategy="runner_call"` places one checkpoint around the outer
+  runner call. Prefer it when the flow needs a clean `.wait()` return value.
+- `checkpoint_strategy="calls"` is the default granular mode: supported
+  model/tool calls become separate checkpoints. This is useful for fine replay,
+  but it can create multiple terminal checkpoints, so `flow.run(...).wait()` may
+  raise the ambiguous-result error. Inspect artifacts/UI/client output instead,
+  or choose `runner_call`.
+- `OpenAIRunRequest.start(...)` and `OpenAIRunRequest.resume(...)` carry start
+  and resume state.
+- `wait_for_approval(...)` bridges an interrupted OpenAI run into a normal
+  flow-scope Kitaru wait and returns a resume request.
+- `OpenAICapturePolicy` controls saved input/output/run-state/interruption/usage
+  details. Use tool checkpoint overrides for side-effectful tools.
+- `calls` mode must run at flow scope, not inside another checkpoint.
+
+### LangGraph / `KitaruGraphRunner`
+
+Use `KitaruGraphRunner` for LangGraph graphs and LangChain/Deep Agents objects
+that behave like LangGraph runnables.
+
+- `checkpoint_strategy="graph_call"` is the default coarse boundary: one Kitaru
+  checkpoint per outer `invoke(...)` / `ainvoke(...)` call.
+- `checkpoint_strategy="calls"` creates true sync model/tool checkpoints only
+  when `KitaruLangGraphMiddleware` wraps the LangChain handler call. Callbacks
+  and event streams are trace-only; they are not replay boundaries.
+- Async calls mode is metadata-only today. `async_checkpoint_policy` is not a
+  hidden switch for true async checkpoints.
+- LangGraph checkpointers and stores remain LangGraph-owned. If examples use
+  `InMemorySaver`, treat it as a local LangGraph checkpointer, not durable
+  Kitaru state.
+- `wait_for_interrupt(...)` bridges LangGraph interrupts to flow-scope
+  `kitaru.wait(...)` and returns a resume request.
+- `LangGraphCapturePolicy` defaults to metadata-first summaries; saving full
+  state values can persist prompts, tool outputs, or customer data.
+
+### Claude Agent SDK / `KitaruClaudeRunner`
+
+Use `KitaruClaudeRunner` when one Claude SDK invocation should be durable.
+
+- `checkpoint_strategy="invocation"` is the only supported strategy and is the
+  default. `"calls"`, `"runner_call"`, `"model_call"`, and `"tool_call"` are
+  rejected because the adapter does not provide granular Claude-internal replay.
+- Put `runner.run(...)` / `runner.run_sync(...)` directly in the flow body so the
+  adapter can create its invocation checkpoint. Calling from inside an existing
+  checkpoint is rejected unless you explicitly opt into direct execution and
+  accept replay risk.
+- `ClaudeRunRequest` carries prompt/options such as cwd, session resume ID, and
+  max turns. `ClaudeCapturePolicy` controls saved messages/transcripts/usage and
+  manifest details.
+- Claude session resume and Claude file checkpointing are Claude SDK concepts.
+  Kitaru replay can skip a completed Claude invocation, but it does not recreate
+  arbitrary workspace files, Bash side effects, MCP side effects, hooks, or
+  custom-tool side effects made inside Claude's loop.
+- If a side effect must be durable, make it a separate Kitaru checkpoint after
+  Claude returns.
 
 ## Common mistakes checklist
 
@@ -358,8 +468,8 @@ def my_flow(topic: str) -> str:
 - Using vague or duplicate checkpoint / wait names that make replay selectors
   hard to target
 - Reusing artifact names so `load()` becomes ambiguous
-- Inventing removed key-value state APIs instead of using artifacts or an
-  external store
+- Inventing removed native-memory/key-value state APIs instead of using
+  artifacts or an external store
 - Using `wait.*` override keys in replay (they are not supported)
 - Assuming CLI, client, and MCP expose the same operation set
 - Using `KitaruClient` to launch new executions (it's for
@@ -368,10 +478,20 @@ def my_flow(topic: str) -> str:
   `kitaru login` for that)
 - Using SDK `create_stack(...)` for remote stacks (it's local-only; use
   CLI/MCP)
-- Reaching for deferred PydanticAI tools even though they are unsupported here
+- Recommending deprecated PydanticAI `wrap(...)` for new code instead of
+  `KitaruAgent(...)`
+- Using legacy PydanticAI capture modes `metadata_only` or `off` instead of
+  `"metadata"` or `None`
+- Putting adapter wait helpers inside checkpoint-contained tool bodies without a
+  flow-scope bridge or tool-checkpoint opt-out
+- Expecting OpenAI Agents `checkpoint_strategy="calls"` to produce one clean
+  `.wait()` result
+- Wrapping an OpenAI `calls` runner call inside your own checkpoint
+- Treating LangGraph callbacks or event streams as Kitaru replay boundaries
+- Treating LangGraph `InMemorySaver` as durable cross-process storage
+- Expecting Claude Agent SDK `KitaruClaudeRunner` to replay Claude-internal Bash,
+  MCP, custom-tool, hook, permission, or workspace side effects granularly
 - Wrapping every tiny helper in a checkpoint instead of using meaningful replay
   boundaries
-- Wrapping the PydanticAI agent inside the checkpoint function instead of at
-  module scope
-- Using `type="agent_turn"` on a PydanticAI checkpoint instead of
-  `type="llm_call"` (the shipped example pattern)
+- Constructing adapter wrappers inside hot checkpoint functions when module-scope
+  construction is clearer and stable

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -82,9 +82,8 @@ Enforce these rules when writing or reviewing Kitaru code:
    synthetic `llm_call` checkpoint automatically.
 9. Use stable, unique names for checkpoints, waits, and artifacts so replay and
    operations stay unambiguous.
-10. Do not reintroduce removed native-memory APIs. Use artifacts for
-    execution-linked values and external/application-owned stores for mutable
-    cross-execution state.
+10. Use artifacts for execution-linked values and external/application-owned
+    stores for mutable cross-execution state.
 
 ## Primitive reference
 
@@ -162,12 +161,10 @@ one of these explicit patterns instead:
 - Use Kitaru secrets for sensitive configuration and `llm(...)` aliases, not for
   arbitrary workflow state.
 
-Do not invent SDK helpers, CLI commands, or MCP tools for removed native
-key-value state. Specifically, do not recommend `kitaru.memory`,
-`KitaruClient.memories`, `kitaru memory`, or MCP `kitaru_memory_*` tools. When
-replay correctness matters, make the critical value an explicit checkpoint
-output or saved artifact so the exact value from the source execution remains
-inspectable.
+Do not invent SDK helpers, CLI commands, or MCP tools for native durable
+key-value state. When replay correctness matters, make the critical value an
+explicit checkpoint output or saved artifact so the exact value from the source
+execution remains inspectable.
 
 ### `llm(...)`
 
@@ -468,8 +465,8 @@ Use `KitaruClaudeRunner` when one Claude SDK invocation should be durable.
 - Using vague or duplicate checkpoint / wait names that make replay selectors
   hard to target
 - Reusing artifact names so `load()` becomes ambiguous
-- Inventing removed native-memory/key-value state APIs instead of using
-  artifacts or an external store
+- Treating Kitaru as a durable key-value store instead of using artifacts or an
+  external store
 - Using `wait.*` override keys in replay (they are not supported)
 - Assuming CLI, client, and MCP expose the same operation set
 - Using `KitaruClient` to launch new executions (it's for

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -266,7 +266,7 @@ inspection**, not for launching new executions.
     provisioning
 - `model register / list`
 - `secrets set / show / list / delete`
-- `build`, `deploy`, `invoke`, and `flow deployments list/get/delete/tag/untag/logs/curl`
+- `build`, `deploy`, `invoke`, `flow deployments list/show/delete/logs/curl`, and `flow tag` / `flow untag`
 - `executions get / list / logs / input / replay / retry / resume / cancel`
 - List commands use `--page` / `--size` pagination where documented; `--limit`
   is a first-page shortcut for compatible lists

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -699,8 +699,7 @@ Enforce these rules throughout the entire session:
 12. **Checkpoint outputs must be serializable**: All mock return values from
     checkpoints must be JSON-serializable: strings, numbers, lists, and dicts.
 
-13. **No native memory APIs**: Do not introduce `kitaru.memory`,
-    `KitaruClient.memories`, `kitaru memory`, or `kitaru_memory_*` in this
-    quickstart. Durable cross-execution application state belongs in the user's
-    own database/object store/repository/service, with explicit values or stable
-    references passed into flows.
+13. **Use application-owned state stores**: Durable cross-execution application
+    state belongs in the user's own database/object store/repository/service,
+    with explicit values or stable references passed into flows. Replay-critical
+    values should be explicit checkpoint outputs or saved artifacts.

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -49,12 +49,13 @@ properly. Then default to the research/content track for the demo.
 
 - **Raw Python** (default) — no dependencies beyond Kitaru, uses mock
   functions with `time.sleep()`
-- **PydanticAI** — uses `TestModel`, no API keys needed
+- **PydanticAI** — discussed as a follow-up, no API keys in the quickstart
 - **Simplest working path** — you choose
 
 For v1, use the raw Python track template regardless of choice. If the user
 specifically requests PydanticAI, complete the quickstart in raw Python and
-then offer `/kitaru-authoring` for PydanticAI conversion.
+then offer `/kitaru-authoring` for adapter conversion. Keep adapters,
+deployments, and production architecture out of this beginner tour.
 
 ### Question 3: Depth
 
@@ -109,7 +110,7 @@ This is a tutorial, not a firehose. Throughout the session:
    python3 --version
    uv --version
    ```
-   Require Python 3.10+. If `uv` is missing, suggest:
+   Require Python 3.11+. If `uv` is missing, suggest:
    `curl -LsSf https://astral.sh/uv/install.sh | sh`
 
 3. **Choose the demo project directory before creating anything**:
@@ -132,7 +133,7 @@ This is a tutorial, not a firehose. Throughout the session:
    cd "$DEMO_DIR"
    pwd
    uv init --no-workspace
-   uv add 'kitaru[local,mcp]>=0.4.0'
+   uv add 'kitaru[local,mcp]>=0.12.0'
    ```
 
    Store the printed `pwd` value as `<ABSOLUTE_DEMO_DIR>`.
@@ -140,7 +141,7 @@ This is a tutorial, not a firehose. Throughout the session:
    If `uv add` says only an older Kitaru version is available, explain that
    an ancestor `exclude-newer` setting may be filtering PyPI. Move the demo
    to a neutral path and retry. If it still fails, stop with the clear
-   message that this quickstart needs Kitaru `>=0.4.0` because it expects the
+   message that this quickstart needs Kitaru `>=0.12.0` because it expects the
    current local server, replay, wait, artifact, and MCP surfaces.
 
 4. **Initialize and verify Kitaru**:
@@ -165,7 +166,7 @@ This is a tutorial, not a firehose. Throughout the session:
 
    Pause here and wait for acknowledgement. If local server startup fails
    because local dependencies are missing, rerun
-   `uv add 'kitaru[local,mcp]>=0.4.0'` and retry once. If the dashboard is
+   `uv add 'kitaru[local,mcp]>=0.12.0'` and retry once. If the dashboard is
    unavailable but `uv run kitaru status` works, ask whether to continue with
    CLI-only inspection.
 
@@ -448,9 +449,12 @@ Only run this phase if the user chose **guided build + MCP**.
 ### Step 1: Explain the value
 
 > "I can configure your agent host so it can query Kitaru's execution state,
-> provide input to waiting flows, and trigger replays through MCP. Because MCP
-> hosts often launch outside your activated shell, we will point the host at
-> the demo project's uv environment explicitly."
+> provide input to waiting flows, and trigger replays through MCP. The current
+> MCP server also exposes deployment tools, artifact tools, metadata-only secret
+> creation, status, stack, and local-server tools, but this quickstart will only
+> demo the beginner-safe execution/artifact path. Because MCP hosts often launch
+> outside your activated shell, we will point the host at the demo project's uv
+> environment explicitly."
 
 ### Step 2: Detect the host
 
@@ -467,7 +471,7 @@ If no markers are found or multiple match, ask which host the user is using.
 Phase 0 installs the MCP extra. If that was skipped or changed, run:
 
 ```bash
-uv add 'kitaru[local,mcp]>=0.4.0'
+uv add 'kitaru[local,mcp]>=0.12.0'
 ```
 
 Then verify through the project environment:
@@ -531,8 +535,12 @@ If a wait is currently pending, also demonstrate:
 
 If applicable:
 5. **Replay** — trigger a replay via MCP
+6. **Artifacts** — list or inspect the saved final artifact
 
-Keep the MCP demo focused on executions, wait input, replay, logs, and artifact inspection.
+Name, but do not exercise, the broader tool categories: deployments,
+metadata-only secret creation, status/stacks, and local-server start/stop.
+Keep the MCP demo focused on executions, wait input, replay, logs, and artifact
+inspection.
 
 ### Step 8: Handle failure
 
@@ -594,7 +602,7 @@ uv run kitaru executions input <EXEC_ID> --value true
 
 ## Next steps
 - **`/kitaru-scoping`** — Design durability for a real workflow
-- **`/kitaru-authoring`** — Refactor existing code with Kitaru primitives
+- **`/kitaru-authoring`** — Refactor existing code with Kitaru primitives, current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK), deployments, secrets, and operational surfaces
 
 ## Resources
 - [Kitaru documentation](https://kitaru.ai/docs)
@@ -616,7 +624,8 @@ summary matches what they learned.
 > - **`/kitaru-scoping`** if you want to design durability for a real
 >   workflow
 > - **`/kitaru-authoring`** if you have existing code you'd like to
->   refactor with Kitaru primitives
+>   refactor with Kitaru primitives, adapters, deployments, secrets, or
+>   operational controls
 
 ### Step 3: Offer cleanup, defaulting to keep
 
@@ -666,7 +675,7 @@ Enforce these rules throughout the entire session:
 
 8. **Real commands only**: Use only documented Kitaru CLI commands and this
    quickstart's validated forms:
-   - Install: `uv add 'kitaru[local,mcp]>=0.4.0'`
+   - Install: `uv add 'kitaru[local,mcp]>=0.12.0'`
    - Local server/dashboard: `uv run kitaru login`, then open
      `http://127.0.0.1:8383`
    - Guided replay: `uv run python demo_flow.py --replay <id>`
@@ -689,3 +698,9 @@ Enforce these rules throughout the entire session:
 
 12. **Checkpoint outputs must be serializable**: All mock return values from
     checkpoints must be JSON-serializable: strings, numbers, lists, and dicts.
+
+13. **No native memory APIs**: Do not introduce `kitaru.memory`,
+    `KitaruClient.memories`, `kitaru memory`, or `kitaru_memory_*` in this
+    quickstart. Durable cross-execution application state belongs in the user's
+    own database/object store/repository/service, with explicit values or stable
+    references passed into flows.

--- a/skills/kitaru-quickstart/references/mcp-config-guide.md
+++ b/skills/kitaru-quickstart/references/mcp-config-guide.md
@@ -8,13 +8,13 @@ is not directly supported.
 With uv:
 
 ```bash
-uv add 'kitaru[mcp]>=0.4.0'
+uv add 'kitaru[mcp]>=0.12.0'
 ```
 
 Or with pip:
 
 ```bash
-pip install 'kitaru[mcp]>=0.4.0'
+pip install 'kitaru[mcp]>=0.12.0'
 ```
 
 ## Verify installation from the project environment
@@ -95,8 +95,18 @@ Once configured, the Kitaru MCP server exposes these tools:
 - `kitaru_executions_replay` — replay from a checkpoint
 - `kitaru_executions_cancel` — cancel a running execution
 - `get_execution_logs` — read execution logs when the active log backend has entries
+- `kitaru_deployments_deploy` — create a deployment version from a flow target
+- `kitaru_deployments_invoke` — start an execution from a deployment
+- `kitaru_deployments_list` — list deployment versions
+- `kitaru_deployments_get` — inspect a deployment version or tag
+- `kitaru_deployments_delete` — delete a deployment version
+- `kitaru_deployments_tag` — attach or move a public deployment tag
+- `kitaru_deployments_untag` — remove a public deployment tag
 - `kitaru_artifacts_list` — list artifacts for an execution
 - `kitaru_artifacts_get` — read an artifact
+- `kitaru_secrets_create` — create a secret and return metadata only
+- `kitaru_start_local_server` — start a local Kitaru server
+- `kitaru_stop_local_server` — stop the local Kitaru server
 - `kitaru_status` — check Kitaru connection status
 - `kitaru_stacks_list` — list available stacks
 - `manage_stack` — create or delete stacks

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -258,11 +258,11 @@ Use an **external system** when the value is mutable application state shared
 across many executions, users, or services. Good homes include a database, an
 object store, a repository file, or an existing service API.
 
-Native Kitaru memory was removed in Kitaru 0.11.0. Do not design around
-`kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, or MCP
-`kitaru_memory_*` tools. If source docs mention LangGraph `InMemorySaver`, treat
-that only as LangGraph-owned checkpointer terminology, not as a Kitaru memory
-API.
+Do not design around native durable key-value state in Kitaru. Cross-execution
+mutable state belongs in external/application-owned storage, while
+replay-critical values should be explicit checkpoint outputs or saved artifacts.
+If source docs mention LangGraph `InMemorySaver`, treat that only as
+LangGraph-owned checkpointer terminology, not as a Kitaru state API.
 
 A simple test:
 
@@ -442,8 +442,7 @@ Review the proposed design for these smells:
 - LangGraph designs that assume Kitaru replaces the graph checkpointer/store
 - Claude Agent SDK designs that expect granular replay of Claude-internal Bash,
   MCP, custom tool, hook, permission, or workspace side effects
-- Native-memory designs using removed `kitaru.memory`, `KitaruClient.memories`,
-  `kitaru memory`, or `kitaru_memory_*` APIs
+- designs that expect Kitaru to provide native durable key-value state
 - cross-flow artifact designs with no plan for how downstream flows receive
   upstream execution IDs
 

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -12,9 +12,11 @@ description: >-
   right for their use case, seems unsure about where to place checkpoints or
   waits, needs to choose between SDK / KitaruClient / CLI / MCP control
   surfaces, asks how to handle state across executions, or arrives with a
-  workflow that might be too simple or too complex for Kitaru. Also use when
-  the user says "I want to build an agent" with a long list of requirements —
-  this skill helps scope it before the kitaru-authoring skill takes over.
+  workflow that might be too simple or too complex for Kitaru, or needs to
+  choose among PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK
+  adapter boundaries. Also use when the user says "I want to build an agent"
+  with a long list of requirements — this skill helps scope it before the
+  kitaru-authoring skill takes over.
 ---
 
 # Scope Kitaru Flow Architectures
@@ -46,20 +48,30 @@ Kitaru is a durable execution layer for Python workflows built around four
 user-facing surfaces:
 
 - **SDK primitives**: `@flow`, `@checkpoint`, `wait()`, `log()`, `save()`,
-  `load()`, `llm()`, plus configuration helpers (`configure`, `connect`,
-  `create_stack`, `list_stacks`, `current_stack`, `use_stack`, `delete_stack`)
-- **KitaruClient** (inspection/control plus artifact inspection):
+  `load()`, `llm()`, `current_execution_id()`, plus configuration helpers,
+  local-stack helpers, and secret helpers (`create_secret`, `delete_secret`,
+  `get_secret`)
+- **KitaruClient** (inspection/control plus artifact and deployment operations):
   `executions.get / list / latest / logs / pending_waits / input / abort_wait /
-  retry / resume / replay / cancel` and `artifacts.list / get`
-- **CLI control**: `kitaru login`, `kitaru executions ...`, stack/model/secret
-  commands (including remote stack creation for `kubernetes`, `vertex`,
-  `sagemaker`, `azureml`), and runtime inspection commands
-- **MCP control**: execution tools (`kitaru_executions_list/get/latest/run/
-  input/retry/replay/cancel`), artifact tools, status, stack listing, and
-  `manage_stack` (create/delete including remote stacks).
+  retry / resume / replay / cancel`, `artifacts.list / get`, deployment
+  inspection/invocation, and auth-management namespaces
+- **CLI control**: `kitaru login`, `kitaru auth token`, `kitaru executions ...`,
+  `kitaru build/deploy/invoke`, `kitaru flow deployments ...`, stack/model/secret
+  commands, `clean`, `info`, and `analytics`
+- **MCP control**: execution tools, deployment tools, artifact tools,
+  metadata-only secret creation, local-server/status/stack tools, and
+  `manage_stack`.
 
-It also ships a **PydanticAI adapter** (`wrap(...)`, `hitl_tool(...)`) for agent
-workloads that want Kitaru tracking without rewriting the whole control flow.
+It also ships four adapter families. Scope them as design choices, not as one
+universal answer:
+
+- **PydanticAI** — `KitaruAgent` for durable PydanticAI runs and tool/MCP calls
+- **OpenAI Agents** — `KitaruRunner` for OpenAI Agents SDK runs
+- **LangGraph** — `KitaruGraphRunner` for graph calls or middleware-observed sync calls
+- **Claude Agent SDK** — `KitaruClaudeRunner` for whole Claude SDK invocations
+
+`wrap(...)` still exists as a deprecated PydanticAI migration shim, but new
+designs should use `KitaruAgent(...)` directly.
 
 ### Execution model
 
@@ -208,6 +220,9 @@ These are not style preferences. They are actual implementation boundaries.
 - Flows do not nest.
 - Checkpoints do not nest.
 - `wait()` can only run in the flow body, never inside a checkpoint.
+- Adapter wait helpers follow the same rule. If a PydanticAI/OpenAI/LangGraph
+  tool body needs to pause, keep the bridge at flow scope or opt that tool out
+  of granular adapter checkpoints where the adapter supports that opt-out.
 - `save()` and `load()` require checkpoint scope.
 - `log()` can run in flow scope or checkpoint scope.
 - `llm()` is valid only inside a `@flow`; outside a checkpoint it gets a
@@ -243,6 +258,12 @@ Use an **external system** when the value is mutable application state shared
 across many executions, users, or services. Good homes include a database, an
 object store, a repository file, or an existing service API.
 
+Native Kitaru memory was removed in Kitaru 0.11.0. Do not design around
+`kitaru.memory`, `KitaruClient.memories`, `kitaru memory`, or MCP
+`kitaru_memory_*` tools. If source docs mention LangGraph `InMemorySaver`, treat
+that only as LangGraph-owned checkpointer terminology, not as a Kitaru memory
+API.
+
 A simple test:
 
 - If the workflow needs "the exact draft produced in execution X" or "the exact
@@ -275,7 +296,7 @@ operated.
 
 Ask which surface will be used for each job:
 
-- launch or deploy the flow
+- launch, deploy, or invoke the flow
 - inspect execution status
 - read logs
 - provide wait input
@@ -284,6 +305,12 @@ Ask which surface will be used for each job:
 - cancel a stuck run
 - inspect artifacts
 - create/manage stacks
+- create/read/delete secrets
+- obtain short-lived auth tokens for raw HTTP calls
+- generate deployment curl commands for operators or CI
+- reset local/project state with `clean`
+- gather diagnostics with `info`
+- manage anonymous analytics preference
 
 Use these rules:
 
@@ -291,8 +318,10 @@ Use these rules:
 - **KitaruClient** for programmatic inspection and control of existing
   executions and artifacts
 - **CLI** for human operators and shell-based workflows; also the only way to
-  log in with managed workspace names/IDs
-- **MCP** for agent tools and LLM-assisted operations
+  log in with managed workspace names/IDs, print short-lived auth tokens, run
+  `flow deployments curl`, and use `clean` / `info` / `analytics`
+- **MCP** for agent tools and LLM-assisted operations, including deployments
+  and metadata-only secret creation
 
 Important asymmetries to account for in the design:
 
@@ -308,6 +337,17 @@ Important asymmetries to account for in the design:
 | List pending waits | No | Yes | No | No |
 | Create local stack | Yes | No | Yes | Yes |
 | Create remote stack | No | No | Yes | Yes |
+| Deploy flow version | No (use CLI or server APIs) | Limited deployment namespace | Yes | Yes |
+| Invoke deployment | No (use deployment endpoint/client) | Yes | Yes | Yes |
+| Create secret | Yes | No | Yes | Yes (metadata only) |
+| Delete secret | Yes | No | Yes | No |
+| Print auth token / curl command | No | No | Yes | No |
+| Clean/reset local state | No | No | Yes | No |
+| Diagnostics (`info`) | Limited helpers | No | Yes | Status only |
+| Analytics preference | No | No | Yes | No |
+
+List-style CLI commands use paginated windows by default (`--page`, `--size`),
+with `--limit` kept as a first-page shortcut where documented.
 
 ## Phase 5: Replay strategy
 
@@ -337,25 +377,49 @@ checkpoint output or saved artifact first.
 When scoping, write down which checkpoint names are intended to be stable public
 replay selectors.
 
-## Phase 6: PydanticAI-specific guidance
+## Phase 6: Adapter strategy
 
-When the user is building with PydanticAI, scope the workflow around the outer
-agent turn, not every internal model call.
+If the workflow uses an agent framework, choose the adapter boundary before
+writing code. The decision is concrete: where does Kitaru get to put a replay
+save point?
 
-Use these rules:
+### PydanticAI / `KitaruAgent`
 
-- `wrap(...)` is for agent/model/tool tracking under Kitaru; wrap the agent once
-  at module scope and reuse the wrapped reference
-- keep explicit outer checkpoints with `type="llm_call"` around major agent
-  turns for clear replay boundaries
-- `hitl_tool(...)` is a tool marker/decorator that bridges tool-time approvals
-  back to flow-level `wait(...)` — it is not the wait primitive itself
-- deferred tool flows (`ApprovalRequired`, `CallDeferred`) are not supported in
-  the current adapter; do not design a workflow around them
-- MCP-backed toolsets are supported (via `KitaruMCPToolset`), so they can be
-  part of the design if the user already relies on MCP tools
-- only `run()` and `run_sync()` are explicitly synthetic-checkpointed at flow
-  scope; do not assume `iter()` behaves identically
+Use `KitaruAgent(...)` when the user already has a PydanticAI `Agent` and wants
+Kitaru to record model, tool, and MCP calls. Default granular mode gives model,
+tool, and MCP calls their own checkpoints; `granular_checkpoints=False` keeps a
+coarser one-checkpoint-per-turn shape. Use `CapturePolicy` to decide what is
+saved. `hitl_tool(...)` and `wait_for_input(...)` bridge tool-time human input
+back to flow-scope waits. Do not recommend `wrap(...)` for new code; mention it
+only as a deprecated migration shim.
+
+### OpenAI Agents / `KitaruRunner`
+
+Use `KitaruRunner(...)` when the agent is built on the OpenAI Agents SDK. Choose
+`checkpoint_strategy="runner_call"` when the flow needs one clean returned result
+from `.wait()`. Choose `checkpoint_strategy="calls"` when finer model/tool
+replay boundaries matter; explain that this can produce multiple terminal
+checkpoints, so the final flow result may be ambiguous and should be inspected
+through artifacts/client/UI instead.
+
+### LangGraph / `KitaruGraphRunner`
+
+Use `KitaruGraphRunner(...)` when the runtime seam is a LangGraph graph or a
+LangChain/Deep Agents object that behaves like one. `graph_call` is the default
+coarse outer checkpoint. `calls` requires Kitaru LangGraph middleware and creates
+true sync model/tool checkpoints only at middleware-owned call sites. LangGraph
+checkpointers and stores remain LangGraph-owned; Kitaru does not replace them.
+If `InMemorySaver` appears in examples, treat it as a local LangGraph
+checkpointer that is not restart-durable.
+
+### Claude Agent SDK / `KitaruClaudeRunner`
+
+Use `KitaruClaudeRunner(...)` when a Claude SDK invocation should become one
+Kitaru checkpoint. This is deliberately coarse: Claude-internal Bash, MCP,
+custom tool, hook, permission, and workspace side effects are not granular
+Kitaru replay boundaries. If a file write or API call must be durable, put that
+side effect in its own Kitaru checkpoint after Claude returns. Claude session
+resume and Claude file checkpointing are Claude SDK features, not Kitaru replay.
 
 ## Phase 7: Check anti-patterns
 
@@ -370,7 +434,16 @@ Review the proposed design for these smells:
 - assuming CLI, client, and MCP all expose the same controls
 - using `KitaruClient` to launch executions (it can't — use flow objects)
 - using SDK `create_stack(...)` for remote stacks (it's local-only)
-- PydanticAI designs that depend on deferred tools
+- PydanticAI designs that recommend deprecated `wrap(...)` for new code
+- PydanticAI tool-body waits that are not kept at flow scope or opted out of
+  granular tool checkpoints
+- OpenAI Agents `calls` designs that still expect a single clean `.wait()` value
+- LangGraph designs that treat callbacks/event streams as replay boundaries
+- LangGraph designs that assume Kitaru replaces the graph checkpointer/store
+- Claude Agent SDK designs that expect granular replay of Claude-internal Bash,
+  MCP, custom tool, hook, permission, or workspace side effects
+- Native-memory designs using removed `kitaru.memory`, `KitaruClient.memories`,
+  `kitaru memory`, or `kitaru_memory_*` APIs
 - cross-flow artifact designs with no plan for how downstream flows receive
   upstream execution IDs
 
@@ -415,7 +488,7 @@ guide.
 - **Not a Kitaru concern**: [pieces that should stay outside the flow]
 
 ## Operator Surface
-- **Launch / deploy**: [SDK flow object / Python entrypoint | MCP] (not KitaruClient; not CLI)
+- **Launch / deploy**: [SDK flow object / Python entrypoint | CLI deploy/invoke | deployment endpoint | MCP] (not KitaruClient for raw new flow launches)
 - **Logs / inspection**: [KitaruClient | CLI | MCP]
 - **Wait input**: [KitaruClient | CLI | MCP]
 - **Wait abort**: [KitaruClient] (only surface with abort_wait)
@@ -423,6 +496,7 @@ guide.
 - **Replay / cancel**: [surface]
 - **Artifact inspection**: [KitaruClient | MCP] (not CLI)
 - **Stack management**: [SDK (local only) | CLI (local + remote) | MCP (local + remote)]
+- **Secrets/auth/diagnostics**: [SDK secret helpers | CLI secrets/auth token/info/clean/analytics | MCP metadata-only secret creation/status]
 
 ## State and Artifact Strategy
 - **Execution-linked values**: [what should be saved as artifacts]


### PR DESCRIPTION
## What changed

- Refreshed all three Kitaru Claude Code skills for the current Kitaru 0.12 surface.
- Updated authoring/scoping guidance for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK adapters.
- Kept quickstart focused on the beginner crash/replay/wait/artifact/MCP path while updating the install floor and next-step pointers.
- Added native-memory removal guardrails and updated contributor guidance in AGENTS.md / CLAUDE.md.
- Bumped plugin metadata to 0.5.0 in all version fields.

## Why it was needed

The skills were still teaching an older PydanticAI-centered shape. Kitaru now has multiple adapter families, current CLI/MCP/deployment/secret surfaces, and no native memory API. Because skills directly guide generated code, stale wording could lead Claude Code to produce deprecated adapter patterns or removed API calls.

## Key implementation decisions

- Quickstart remains intentionally small: no adapter or deployment walkthroughs were added.
- `wrap(...)` is retained only as deprecated/migration context; new PydanticAI guidance points to `KitaruAgent`.
- Memory wording is negative guardrail wording only: users are directed to external/application-owned storage for cross-execution state.

## Reviewer Notes

The main story to review is in the skill boundary split. `kitaru-quickstart` should still feel like a first demo; `kitaru-scoping` should help choose an architecture and adapter family; `kitaru-authoring` should contain the concrete API guidance.

The highest-risk area is accidental resurrection of removed memory APIs. Please check that memory terms appear only as “do not use this removed API” guardrails, not as recommended Kitaru features. The other tricky area is adapter specificity: each adapter should be named clearly enough for Claude Code to choose the right path, without copying the full public docs into the skill.

### Reproduction

1. Install this plugin branch locally in Claude Code.
2. Invoke `/kitaru-quickstart` and confirm the guided demo still focuses on local replay/wait/artifact/MCP basics.
3. Invoke `/kitaru-scoping` with a LangGraph or OpenAI Agents workflow idea and confirm the skill asks architecture-level adapter questions instead of forcing PydanticAI.
4. Invoke `/kitaru-authoring` for a PydanticAI workflow and confirm it recommends `KitaruAgent`, not `wrap(...)`.

Local checks run:

```text
jq . .claude-plugin/plugin.json
jq . .claude-plugin/marketplace.json
python3 markdown fence check over 12 markdown files
python3 -m py_compile skills/kitaru-quickstart/references/tracks/*.py
uv neutral-project install/import check for kitaru[local,mcp]>=0.12.0
forbidden memory/deprecated PydanticAI searches
```
