### PR TITLE
Reframe Kitaru skills as agent agnostic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
     "url": "https://zenml.io"
   },
   "metadata": {
-    "description": "Three Kitaru skills for quickstart onboarding, durable flow scoping, and authoring with current adapter families",
+    "description": "Three Kitaru Agent Skills for quickstart onboarding, durable flow scoping, and authoring with current adapter families",
     "version": "0.5.0",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
@@ -15,7 +15,7 @@
     {
       "name": "kitaru",
       "source": "./",
-      "description": "Bundles three Kitaru skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), and kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK).",
+      "description": "Claude Code package bundling three Kitaru Agent Skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), and kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK).",
       "version": "0.5.0",
       "author": {
         "name": "ZenML",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kitaru",
-  "description": "Kitaru skills for Claude Code: quickstart onboarding, scoping durable flow architecture, and authoring with current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK)",
+  "description": "Claude Code distribution for Kitaru Agent Skills: quickstart onboarding, scoping durable flow architecture, and authoring with current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK)",
   "version": "0.5.0",
   "author": {
     "name": "ZenML",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,15 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This repository is a Claude Code plugin, not a Python package. Keep contributor work focused on the plugin metadata and skill documents:
+This repository contains **Kitaru Agent Skills** plus Claude Code plugin metadata; it is not a Python package. Keep contributor work focused on the skill documents, portable host guidance, and Claude Code distribution metadata:
 
 - `skills/kitaru-quickstart/SKILL.md` defines the interactive onboarding skill.
 - `skills/kitaru-scoping/SKILL.md` defines the workflow-scoping skill.
 - `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
-- `.claude-plugin/plugin.json` contains plugin metadata such as name, version, and repository URL.
-- `.claude-plugin/marketplace.json` defines the marketplace entry used for local/plugin testing.
-- `README.md` is the public-facing usage and installation guide.
+- `.claude-plugin/plugin.json` contains Claude Code plugin metadata such as name, version, and repository URL.
+- `.claude-plugin/marketplace.json` defines the Claude Code marketplace entry used for local/plugin testing.
+- `README.md` is the public-facing usage, installation, and host guidance.
+- `CLAUDE.md` is Claude Code-specific contributor guidance. Shared repo guidance belongs here in `AGENTS.md`.
 
 When adding a new skill, follow the existing pattern: `skills/<skill-name>/SKILL.md`.
 
@@ -20,37 +21,41 @@ There is no build step in this repo. Most contributor work is editing Markdown a
 - `git diff --stat` gives a compact review of changed files.
 - `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
 
-For manual smoke testing, follow the install commands in [`README.md`](README.md) and verify the plugin exposes `/kitaru-quickstart`, `/kitaru-scoping`, and `/kitaru-authoring`.
+For manual Claude Code smoke testing, follow the install commands in [`README.md`](README.md) and verify the Claude Code distribution route exposes `/kitaru-quickstart`, `/kitaru-scoping`, and `/kitaru-authoring`.
 
 ## Coding Style & Naming Conventions
-Use Markdown for prose and JSON for plugin metadata. Match the existing style:
+Use Markdown for prose and JSON for Claude Code plugin metadata. Match the existing style:
 
 - Use concise headings and short paragraphs.
 - Wrap lines at a readable width similar to the current files.
 - Keep examples concrete and technically accurate.
-- Use kebab-case for skill directory names and slash commands, for example `kitaru-scoping`.
+- Use kebab-case for skill directory names and skill names, for example `kitaru-scoping`.
+- Mention slash commands as Claude Code invocation examples, not as the portable identity of a skill.
 - Preserve valid JSON with two-space indentation in `.claude-plugin/*.json`.
 
 ## Testing Guidelines
 There is currently no dedicated automated test suite. Treat testing as documentation validation:
 
 - Check that examples match the current Kitaru API surface.
-- Confirm new trigger phrases and command names are consistent across `SKILL.md`, `README.md`, and plugin metadata.
+- Confirm new trigger phrases, skill names, and Claude Code slash commands are consistent across `SKILL.md`, `README.md`, `CLAUDE.md`, and plugin metadata.
+- Confirm README host guidance does not claim automatic Codex or Cursor installation.
+- Confirm README links to the Claude Code, Codex, and Cursor MCP host guides where relevant.
+- Confirm `.claude-plugin/` remains valid Claude Code metadata rather than being treated as the whole repo identity.
 - Re-read edited Markdown in rendered form when possible to catch broken lists, code fences, or tables.
 - Validate `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` with `jq .` or equivalent.
 - Run a memory-regression search for removed native memory terms before finishing.
 
 ## Release Sync Checklist
 
-When updating the plugin for a new Kitaru release, verify current source of truth
+When updating the skills package for a new Kitaru release, verify current source of truth
 before editing skill prose:
 
 - Adapter exports under `kitaru/src/kitaru/adapters/*/__init__.py`
 - Current adapter guides for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK
 - MCP server docs for current tool names and categories
 - `CHANGELOG.md` and `pyproject.toml` for release facts and removed APIs
-- Skill inventory and slash command names across README, AGENTS, CLAUDE, metadata, and frontmatter
-- All three plugin metadata version fields: `.claude-plugin/plugin.json` `version`, `.claude-plugin/marketplace.json` `metadata.version`, and `.claude-plugin/marketplace.json` `plugins[0].version`
+- Skill inventory, portable skill names, and Claude Code slash command names across README, AGENTS, CLAUDE, metadata, and frontmatter
+- All three Claude Code plugin metadata version fields: `.claude-plugin/plugin.json` `version`, `.claude-plugin/marketplace.json` `metadata.version`, and `.claude-plugin/marketplace.json` `plugins[0].version`
 - Markdown validity: headings, tables, code fences, and beginner quickstart pacing
 
 Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository. Shared, host-agnostic contributor guidance lives in [`AGENTS.md`](AGENTS.md).
 
 ## What this repo is
 
-This is a **Claude Code skills plugin** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows. It contains no application code; the deliverables are three Markdown skill files plus quickstart references that teach Claude Code how to onboard, scope, and author Kitaru workflows.
+This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are three Markdown skill files plus quickstart references that teach agent hosts how to onboard, scope, and author Kitaru workflows.
 
-The plugin is distributed via the Claude Code marketplace as `zenml-io/kitaru-skills`.
+Claude Code distribution is supported through the `.claude-plugin/` metadata and the Claude Code marketplace entry `zenml-io/kitaru-skills`.
 
 ## Repository structure
 
 ```
 .claude-plugin/
-  plugin.json         # Plugin identity, version, keywords
-  marketplace.json    # Marketplace listing metadata
+  plugin.json         # Claude Code plugin identity, version, keywords
+  marketplace.json    # Claude Code marketplace listing metadata
 skills/
   kitaru-quickstart/SKILL.md       # Interactive onboarding → demo flow
   kitaru-quickstart/references/    # Track templates, host guides, MCP config
@@ -21,9 +21,9 @@ skills/
   kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, artifacts, etc.
 ```
 
-- **kitaru-quickstart** (`/kitaru-quickstart`) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
-- **kitaru-scoping** (`/kitaru-scoping`) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
-- **kitaru-authoring** (`/kitaru-authoring`) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, deployments, secrets, and current adapter integrations: PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK.
+- **kitaru-quickstart** (`/kitaru-quickstart` in Claude Code) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
+- **kitaru-scoping** (`/kitaru-scoping` in Claude Code) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
+- **kitaru-authoring** (`/kitaru-authoring` in Claude Code) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, deployments, secrets, and current adapter integrations: PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK.
 
 The intended user workflow is: quickstart → scope → author.
 
@@ -44,7 +44,7 @@ There is no build step, no linter, no test suite. The deliverables are the three
 - Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce old native-memory wording or recommend a Kitaru-owned durable key-value state API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
 - Plugin version is in both `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` — bump all version fields consistently when publishing updates.
 
-## Installation methods (for testing)
+## Installation methods (for Claude Code testing)
 
 ```bash
 # Marketplace

--- a/README.md
+++ b/README.md
@@ -1,29 +1,40 @@
-# Kitaru Skills for Claude Code
+# Kitaru Agent Skills
 
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) skills for
-discovering, designing, and building durable AI agent workflows with
-[Kitaru](https://kitaru.ai).
+Reusable Markdown agent skills for discovering, designing, and building durable
+AI agent workflows with [Kitaru](https://kitaru.ai).
+
+This repository contains the shared skill content plus Claude Code plugin
+packaging. Claude Code can install the skills through its plugin flow. Codex,
+Cursor, and other agent hosts can use the Markdown skill files and the
+host-specific MCP setup guides where their local skill, rule, or context-loading
+workflow supports that pattern.
 
 ## Skills
 
-| Skill | Slash command | Purpose |
+| Skill | Skill / invocation | Purpose |
 |---|---|---|
-| **kitaru-quickstart** | `/kitaru-quickstart` | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
-| **kitaru-scoping** | `/kitaru-scoping` | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
-| **kitaru-authoring** | `/kitaru-authoring` | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK |
+| **kitaru-quickstart** | `kitaru-quickstart` (`/kitaru-quickstart` in Claude Code) | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
+| **kitaru-scoping** | `kitaru-scoping` (`/kitaru-scoping` in Claude Code) | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
+| **kitaru-authoring** | `kitaru-authoring` (`/kitaru-authoring` in Claude Code) | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK |
 
 ### Recommended workflow
 
-1. **Quickstart** — use `/kitaru-quickstart` to see what Kitaru does and
-   build intuition for crash recovery, replay, waits, and artifacts
-2. **Scope** — use `/kitaru-scoping` to validate fit and define your flow
+1. **Quickstart** — use `kitaru-quickstart` to see what Kitaru does and build
+   intuition for crash recovery, replay, waits, and artifacts
+2. **Scope** — use `kitaru-scoping` to validate fit and define your flow
    architecture before writing code
-3. **Author** — use `/kitaru-authoring` to build the flows defined in
-   your `flow_architecture.md`
+3. **Author** — use `kitaru-authoring` to build the flows defined in your
+   `flow_architecture.md`
 
-## Installation
+In Claude Code, those skills are exposed as slash commands:
+`/kitaru-quickstart`, `/kitaru-scoping`, and `/kitaru-authoring`.
 
-### Marketplace (recommended)
+## Installation and usage
+
+### Claude Code plugin distribution
+
+Claude Code users can install the packaged skills from the Claude Code plugin
+marketplace:
 
 ```bash
 /plugin marketplace add zenml-io/kitaru-skills
@@ -34,9 +45,8 @@ Once installed, Claude Code will automatically use the skills based on context.
 You can also invoke them explicitly with `/kitaru-quickstart`,
 `/kitaru-scoping`, or `/kitaru-authoring`.
 
-### Team installation
-
-Add to your project's `.claude/settings.json`:
+For project/team installation, add this to your project's
+`.claude/settings.json`:
 
 ```json
 {
@@ -49,7 +59,7 @@ Add to your project's `.claude/settings.json`:
 }
 ```
 
-### Manual installation
+For manual Claude Code installation during local development:
 
 ```bash
 tmpdir=$(mktemp -d)
@@ -60,6 +70,37 @@ cp -R "$tmpdir/kitaru-skills/skills/kitaru-scoping" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-authoring" .claude/skills/
 rm -rf "$tmpdir"
 ```
+
+See the [Claude Code host guide](skills/kitaru-quickstart/references/hosts/claude-code.md)
+for MCP setup details.
+
+### Codex usage
+
+Codex setup depends on the Codex version and local configuration style you use.
+If your Codex environment supports local skills, copy the three
+`skills/kitaru-*` directories into the supported Codex skills location or load
+the relevant `SKILL.md` files as explicit project context.
+
+For Kitaru MCP setup, follow the cautious host notes in the
+[Codex host guide](skills/kitaru-quickstart/references/hosts/codex.md). Codex
+MCP configuration can vary by installation, so use that guide as a starting
+point and confirm against your current Codex documentation.
+
+### Cursor usage
+
+Cursor does not install this Claude Code plugin automatically. Use the Markdown
+skill files as project rules or agent context according to the Cursor workflow
+you already use.
+
+For Kitaru MCP setup, see the
+[Cursor host guide](skills/kitaru-quickstart/references/hosts/cursor.md), which
+shows the `.cursor/mcp.json` stdio configuration pattern.
+
+### Manual Markdown use
+
+For any other capable agent host, open the relevant `skills/*/SKILL.md` file and
+ask the agent to follow it. This is the portable fallback path when the host does
+not have a formal skill or plugin system.
 
 ## Example prompts
 
@@ -88,8 +129,11 @@ rm -rf "$tmpdir"
 ## Links
 
 - [Kitaru documentation](https://kitaru.ai/docs)
-- [Claude Code Skills docs](https://kitaru.ai/docs/agent-native/claude-code-skill)
+- [Claude Code skill distribution guide](https://kitaru.ai/docs/agent-native/claude-code-skill)
 - [Kitaru SDK repository](https://github.com/zenml-io/kitaru)
+- [Claude Code MCP host guide](skills/kitaru-quickstart/references/hosts/claude-code.md)
+- [Codex MCP host guide](skills/kitaru-quickstart/references/hosts/codex.md)
+- [Cursor MCP host guide](skills/kitaru-quickstart/references/hosts/cursor.md)
 
 ## License
 

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -16,9 +16,9 @@ someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
 waits, artifacts, and the dashboard" in a single teaching session.
 
 > **Relationship to other skills**:
-> - `/kitaru-quickstart` → activation and intuition (this skill)
-> - `/kitaru-scoping` → design durability for a real workflow
-> - `/kitaru-authoring` → refactor production code with Kitaru primitives
+> - `kitaru-quickstart` (`/kitaru-quickstart` in Claude Code) → activation and intuition (this skill)
+> - `kitaru-scoping` (`/kitaru-scoping` in Claude Code) → design durability for a real workflow
+> - `kitaru-authoring` (`/kitaru-authoring` in Claude Code) → refactor production code with Kitaru primitives
 
 ## Before you start
 
@@ -54,7 +54,7 @@ properly. Then default to the research/content track for the demo.
 
 For v1, use the raw Python track template regardless of choice. If the user
 specifically requests PydanticAI, complete the quickstart in raw Python and
-then offer `/kitaru-authoring` for adapter conversion. Keep adapters,
+then offer `kitaru-authoring` (`/kitaru-authoring` in Claude Code) for adapter conversion. Keep adapters,
 deployments, and production architecture out of this beginner tour.
 
 ### Question 3: Depth
@@ -601,8 +601,8 @@ uv run kitaru executions input <EXEC_ID> --value true
   `rm -rf [absolute path]`
 
 ## Next steps
-- **`/kitaru-scoping`** — Design durability for a real workflow
-- **`/kitaru-authoring`** — Refactor existing code with Kitaru primitives, current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK), deployments, secrets, and operational surfaces
+- **`kitaru-scoping`** (`/kitaru-scoping` in Claude Code) — Design durability for a real workflow
+- **`kitaru-authoring`** (`/kitaru-authoring` in Claude Code) — Refactor existing code with Kitaru primitives, current adapters (PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK), deployments, secrets, and operational surfaces
 
 ## Resources
 - [Kitaru documentation](https://kitaru.ai/docs)
@@ -621,11 +621,11 @@ summary matches what they learned.
 
 > "Your quickstart is complete! Here's what you can do next:"
 >
-> - **`/kitaru-scoping`** if you want to design durability for a real
->   workflow
-> - **`/kitaru-authoring`** if you have existing code you'd like to
->   refactor with Kitaru primitives, adapters, deployments, secrets, or
->   operational controls
+> - **`kitaru-scoping`** (`/kitaru-scoping` in Claude Code) if you want to
+>   design durability for a real workflow
+> - **`kitaru-authoring`** (`/kitaru-authoring` in Claude Code) if you have
+>   existing code you'd like to refactor with Kitaru primitives, adapters,
+>   deployments, secrets, or operational controls
 
 ### Step 3: Offer cleanup, defaulting to keep
 


### PR DESCRIPTION
## What changed

- Reframed the repository as **Kitaru Agent Skills** instead of Claude-Code-only skills.
- Kept Claude Code plugin installation as a supported distribution path rather than the whole repo identity.
- Added cautious Codex, Cursor, and manual Markdown usage guidance.
- Updated `AGENTS.md`, `CLAUDE.md`, and Claude plugin metadata so contributor and marketplace wording matches the new framing.
- Adjusted quickstart next-step wording to use portable skill names first, with Claude Code slash commands as host-specific examples.

## Why it was needed

The skill content already supports more than Claude Code in practice, especially through host-specific MCP guides for Claude Code, Codex, and Cursor. The README and contributor docs still told readers the repo was primarily a Claude Code plugin, which could make Codex, Cursor, and other agent users think the skills were not for them.

## Key implementation decisions

- `.claude-plugin/` remains intact because it is still the Claude Code packaging path.
- Codex and Cursor guidance is deliberately cautious: it points users to local skill/context workflows and MCP host guides instead of promising automatic install behavior.
- Claude Agent SDK references remain because those refer to the Kitaru adapter family, not Claude Code as a host.
- Version fields remain unchanged at `0.5.0` because this is not a release bump.

## Reviewer Notes

The important story to review is the boundary between **portable skill content** and **host-specific packaging**. The repo now says: the durable Kitaru teaching material lives in `skills/*/SKILL.md`; Claude Code gets a packaged plugin route through `.claude-plugin/`; Codex, Cursor, and other agents can use the same Markdown skills where their own skill/rule/context systems support it.

The highest-risk area is the README install guidance. Please check that it does not accidentally promise Codex or Cursor a Claude-like plugin install flow. The wording should guide those users toward their current local skill/context setup and the existing MCP host guides.

### Reproduction

1. Open `README.md` and confirm the page starts with `# Kitaru Agent Skills`.
2. Read the “Installation and usage” section:
   - Claude Code should still have concrete plugin install commands.
   - Codex should be framed as dependent on the user’s Codex version/local setup.
   - Cursor should explicitly say it does not install the Claude Code plugin automatically.
3. Open `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`; confirm they still describe Claude Code packaging and keep all version fields at `0.5.0`.
4. Run:

   ```bash
   jq . .claude-plugin/plugin.json
   jq . .claude-plugin/marketplace.json
   rg "Kitaru Skills for Claude Code|This repository is a Claude Code plugin|Claude Code skills for|Kitaru skills for Claude Code" .
   ```

   The JSON commands should pass, and the stale-phrase search should return no matches.

## Local checks run

- `git diff --check -- README.md AGENTS.md CLAUDE.md .claude-plugin/plugin.json .claude-plugin/marketplace.json skills/kitaru-quickstart/SKILL.md`
- `jq . .claude-plugin/plugin.json`
- `jq . .claude-plugin/marketplace.json`
- Oracle review: no P0/P1/P2 findings
