### PR TITLE
Add remaining migration skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
     "url": "https://zenml.io"
   },
   "metadata": {
-    "description": "Five Kitaru Agent Skills for quickstart onboarding, durable flow scoping, authoring with current adapter families, PydanticAI migration, and OpenAI Agents SDK migration",
-    "version": "0.6.0",
+    "description": "Eight Kitaru Agent Skills for quickstart onboarding, durable flow scoping, authoring with current adapter families, and conservative migrations for PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, and Gemini Interactions",
+    "version": "0.7.0",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
   },
@@ -15,8 +15,8 @@
     {
       "name": "kitaru",
       "source": "./",
-      "description": "Claude Code package bundling five Kitaru Agent Skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK), kitaru-pydantic-ai-migration (conservative PydanticAI to KitaruAgent migration), and kitaru-openai-agents-migration (OpenAI Agents SDK to KitaruRunner migration).",
-      "version": "0.6.0",
+      "description": "Claude Code package bundling eight Kitaru Agent Skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, and current adapters), kitaru-pydantic-ai-migration (PydanticAI to KitaruAgent), kitaru-openai-agents-migration (OpenAI Agents SDK to KitaruRunner), kitaru-langgraph-migration (LangGraph/LangChain to KitaruGraphRunner), kitaru-claude-agent-sdk-migration (Claude Agent SDK to KitaruClaudeRunner), and kitaru-gemini-interactions-migration (Gemini Interactions/Antigravity to KitaruGeminiInteractionsRunner).",
+      "version": "0.7.0",
       "author": {
         "name": "ZenML",
         "url": "https://kitaru.ai"
@@ -40,7 +40,16 @@
         "openai-agents",
         "openai-agents-migration",
         "langgraph",
+        "langgraph-migration",
+        "langchain",
         "claude-agent-sdk",
+        "claude-agent-sdk-migration",
+        "gemini",
+        "gemini-interactions",
+        "gemini-interactions-migration",
+        "google-genai",
+        "antigravity",
+        "antigravity-migration",
         "mcp",
         "deployments"
       ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
-  "description": "Claude Code distribution for five Kitaru Agent Skills: quickstart onboarding, durable flow scoping, authoring with current adapters, PydanticAI migration, and OpenAI Agents SDK migration",
-  "version": "0.6.0",
+  "description": "Claude Code distribution for eight Kitaru Agent Skills: quickstart onboarding, durable flow scoping, authoring with current adapters, and conservative migrations for PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, and Gemini Interactions",
+  "version": "0.7.0",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"
@@ -24,6 +24,15 @@
     "openai-agents",
     "openai-agents-migration",
     "langgraph",
-    "claude-agent-sdk"
+    "langgraph-migration",
+    "langchain",
+    "claude-agent-sdk",
+    "claude-agent-sdk-migration",
+    "gemini",
+    "gemini-interactions",
+    "gemini-interactions-migration",
+    "google-genai",
+    "antigravity",
+    "antigravity-migration"
   ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ This repository contains **Kitaru Agent Skills** plus Claude Code plugin metadat
 - `skills/kitaru-authoring/SKILL.md` defines the implementation-authoring skill.
 - `skills/kitaru-pydantic-ai-migration/SKILL.md` defines the PydanticAI migration skill.
 - `skills/kitaru-openai-agents-migration/SKILL.md` defines the OpenAI Agents SDK migration skill.
+- `skills/kitaru-langgraph-migration/SKILL.md` defines the LangGraph migration skill.
+- `skills/kitaru-claude-agent-sdk-migration/SKILL.md` defines the Claude Agent SDK migration skill.
+- `skills/kitaru-gemini-interactions-migration/SKILL.md` defines the Gemini Interactions migration skill.
 - `.claude-plugin/plugin.json` contains Claude Code plugin metadata such as name, version, and repository URL.
 - `.claude-plugin/marketplace.json` defines the Claude Code marketplace entry used for local/plugin testing.
 - `README.md` is the public-facing usage, installation, and host guidance.
@@ -23,7 +26,7 @@ There is no build step in this repo. Most contributor work is editing Markdown a
 - `git diff --stat` gives a compact review of changed files.
 - `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
 
-For manual Claude Code smoke testing, follow the install commands in [`README.md`](README.md) and verify the Claude Code distribution route exposes `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`, and `/kitaru-openai-agents-migration`.
+For manual Claude Code smoke testing, follow the install commands in [`README.md`](README.md) and verify the Claude Code distribution route exposes `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`, `/kitaru-openai-agents-migration`, `/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`, and `/kitaru-gemini-interactions-migration`.
 
 ## Coding Style & Naming Conventions
 Use Markdown for prose and JSON for Claude Code plugin metadata. Match the existing style:
@@ -53,7 +56,7 @@ When updating the skills package for a new Kitaru release, verify current source
 before editing skill prose:
 
 - Adapter exports under `kitaru/src/kitaru/adapters/*/__init__.py`
-- Current adapter guides for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK
+- Current adapter guides for PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini Interactions
 - MCP server docs for current tool names and categories
 - `CHANGELOG.md` and `pyproject.toml` for release facts and removed APIs
 - Skill inventory, portable skill names, and Claude Code slash command names across README, AGENTS, CLAUDE, metadata, and frontmatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are five Markdown skills plus quickstart and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
+This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are eight Markdown skills plus quickstart and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
 
 Claude Code distribution is supported through the `.claude-plugin/` metadata and the Claude Code marketplace entry `zenml-io/kitaru-skills`.
 
@@ -21,19 +21,25 @@ skills/
   kitaru-authoring/SKILL.md        # Authoring guide for flows, checkpoints, waits, artifacts, etc.
   kitaru-pydantic-ai-migration/     # PydanticAI to KitaruAgent migration skill + references
   kitaru-openai-agents-migration/   # OpenAI Agents SDK to KitaruRunner migration skill + references
+  kitaru-langgraph-migration/       # LangGraph to KitaruGraphRunner migration skill + references
+  kitaru-claude-agent-sdk-migration/ # Claude Agent SDK to KitaruClaudeRunner migration skill + references
+  kitaru-gemini-interactions-migration/ # Gemini Interactions to KitaruGeminiInteractionsRunner migration skill + references
 ```
 
 - **kitaru-quickstart** (`/kitaru-quickstart` in Claude Code) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
 - **kitaru-scoping** (`/kitaru-scoping` in Claude Code) — validates whether a workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope). Outputs a `flow_architecture.md`.
-- **kitaru-authoring** (`/kitaru-authoring` in Claude Code) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, deployments, secrets, and current adapter integrations: PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK.
+- **kitaru-authoring** (`/kitaru-authoring` in Claude Code) — reference guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, CLI, MCP, deployments, secrets, and current adapter integrations: PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini Interactions.
 - **kitaru-pydantic-ai-migration** (`/kitaru-pydantic-ai-migration` in Claude Code) — conservative migration guide for existing PydanticAI code moving to `KitaruAgent`, with direct/approximate/absent classification and a migration report.
 - **kitaru-openai-agents-migration** (`/kitaru-openai-agents-migration` in Claude Code) — conservative migration guide for existing OpenAI Agents SDK code moving to `KitaruRunner`, `OpenAIRunRequest`, and `OpenAIRunResult`, with approval/resume, context, and side-effect risk reporting.
+- **kitaru-langgraph-migration** (`/kitaru-langgraph-migration` in Claude Code) — conservative migration guide for existing LangGraph/LangChain code moving to `KitaruGraphRunner`, with `graph_call` vs middleware-backed `calls` boundary reporting.
+- **kitaru-claude-agent-sdk-migration** (`/kitaru-claude-agent-sdk-migration` in Claude Code) — conservative migration guide for existing Claude Agent SDK code moving to `KitaruClaudeRunner`, with one-invocation checkpointing and Claude-owned tool/Bash/MCP/workspace caveats.
+- **kitaru-gemini-interactions-migration** (`/kitaru-gemini-interactions-migration` in Claude Code) — conservative migration guide for existing Gemini Interactions, Google GenAI Interactions, or Antigravity managed-agent code moving to `KitaruGeminiInteractionsRunner`, with `requires_action`, polling, function-result, and Google-owned internals reporting.
 
-The intended user workflow is: quickstart → scope → author for new work, or migration skill → report review → author for existing PydanticAI/OpenAI Agents SDK code.
+The intended user workflow is: quickstart → scope → author for new work, or migration skill → report review → author for existing PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, or Gemini Interactions code.
 
 ## How to work on this repo
 
-There is no build step, no linter, no test suite. The deliverables are the five `SKILL.md` files plus the quickstart and migration reference files. Quality comes from:
+There is no build step, no linter, no test suite. The deliverables are the eight `SKILL.md` files plus the quickstart and migration reference files. Quality comes from:
 
 1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
 2. **Completeness of asymmetry tables** — the skills document capability differences across SDK, KitaruClient, CLI, MCP, deployments, secrets, and adapter surfaces. These tables must stay synchronized between the scoping and authoring skills.
@@ -42,7 +48,7 @@ There is no build step, no linter, no test suite. The deliverables are the five 
 ## Key constraints when editing skills
 
 - The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
-- All five skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored where relevant.
+- All eight skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored where relevant.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
 - The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
 - Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce old native-memory wording or recommend a Kitaru-owned durable key-value state API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
@@ -62,4 +68,7 @@ cp -R skills/kitaru-scoping .claude/skills/
 cp -R skills/kitaru-authoring .claude/skills/
 cp -R skills/kitaru-pydantic-ai-migration .claude/skills/
 cp -R skills/kitaru-openai-agents-migration .claude/skills/
+cp -R skills/kitaru-langgraph-migration .claude/skills/
+cp -R skills/kitaru-claude-agent-sdk-migration .claude/skills/
+cp -R skills/kitaru-gemini-interactions-migration .claude/skills/
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reusable Markdown agent skills for discovering, designing, migrating, and
 building durable AI agent workflows with [Kitaru](https://kitaru.ai).
 
-This repository contains the shared skill content plus Claude Code plugin
+This repository contains eight shared skill directories plus Claude Code plugin
 packaging. Claude Code can install the skills through its plugin flow. Codex,
 Cursor, and other agent hosts can use the Markdown skill files and the
 host-specific MCP setup guides where their local skill, rule, or context-loading
@@ -15,9 +15,12 @@ workflow supports that pattern.
 |---|---|---|
 | **kitaru-quickstart** | `kitaru-quickstart` (`/kitaru-quickstart` in Claude Code) | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
 | **kitaru-scoping** | `kitaru-scoping` (`/kitaru-scoping` in Claude Code) | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
-| **kitaru-authoring** | `kitaru-authoring` (`/kitaru-authoring` in Claude Code) | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK |
+| **kitaru-authoring** | `kitaru-authoring` (`/kitaru-authoring` in Claude Code) | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini Interactions |
 | **kitaru-pydantic-ai-migration** | `kitaru-pydantic-ai-migration` (`/kitaru-pydantic-ai-migration` in Claude Code) | Migrate existing PydanticAI agent code to `KitaruAgent` with conservative boundary selection, direct/approximate/absent classification, HITL safety checks, capture policy guidance, and a migration report |
 | **kitaru-openai-agents-migration** | `kitaru-openai-agents-migration` (`/kitaru-openai-agents-migration` in Claude Code) | Migrate existing OpenAI Agents SDK code to `KitaruRunner`, `OpenAIRunRequest`, and `OpenAIRunResult` with checkpoint strategy selection, approval/resume handling, context serialization checks, and a migration report |
+| **kitaru-langgraph-migration** | `kitaru-langgraph-migration` (`/kitaru-langgraph-migration` in Claude Code) | Migrate existing LangGraph, LangChain `create_agent(...)`, or Deep Agents-style code to `KitaruGraphRunner` with honest `graph_call` vs middleware-backed `calls` boundary selection and a migration report |
+| **kitaru-claude-agent-sdk-migration** | `kitaru-claude-agent-sdk-migration` (`/kitaru-claude-agent-sdk-migration` in Claude Code) | Migrate existing Claude Agent SDK code to `KitaruClaudeRunner` with one invocation checkpoint, Claude-owned tool/Bash/MCP/workspace caveats, capture policy review, and a migration report |
+| **kitaru-gemini-interactions-migration** | `kitaru-gemini-interactions-migration` (`/kitaru-gemini-interactions-migration` in Claude Code) | Migrate existing Gemini Interactions, Google GenAI Interactions, or Antigravity managed-agent code to `KitaruGeminiInteractionsRunner` with `requires_action`, polling, function-result, Antigravity, and Google-owned internals caveats |
 
 ### Recommended workflow
 
@@ -32,26 +35,24 @@ For new Kitaru work:
 
 For existing framework code:
 
-1. **Inspect and classify** — use `kitaru-pydantic-ai-migration` or
-   `kitaru-openai-agents-migration` to identify direct, approximate, and absent
-   mappings before editing code
-2. **Migrate the safe boundary** — wrap PydanticAI agents with `KitaruAgent` or
-   move OpenAI Agents runner calls to `KitaruRunner` requests/results
+1. **Inspect and classify** — use the migration skill that matches the source
+   framework: PydanticAI, OpenAI Agents SDK, LangGraph/LangChain, Claude Agent
+   SDK, or Gemini Interactions
+2. **Migrate the safe boundary** — move only the durable seam Kitaru can honestly
+   see: a wrapped PydanticAI run, an OpenAI Agents runner call or observed call,
+   a LangGraph graph call or middleware-observed sync call, one Claude SDK
+   invocation, or one stable Gemini Interactions response
 3. **Review the report** — use the generated `MIGRATION_REPORT.md` to check
-   replay, wait, state, approval/resume, context, and side-effect risks
+   replay, wait, state, approval/resume, interrupt, polling, context, privacy,
+   and side-effect risks
 4. **Author follow-up Kitaru code** — use `kitaru-authoring` for any additional
    flows, checkpoints, artifacts, CLI/MCP usage, or deployment work
 
 In Claude Code, those skills are exposed as slash commands:
 `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`,
-`/kitaru-pydantic-ai-migration`, and `/kitaru-openai-agents-migration`.
-
-LangGraph, Claude Agent SDK, and Gemini Interactions migration skills are
-intentionally deferred to
-[issue #9](https://github.com/zenml-io/kitaru-skills/issues/9). The existing
-`kitaru-authoring` skill still covers current adapter-authoring guidance for
-LangGraph and Claude Agent SDK; it does not mean those migration skills exist
-yet.
+`/kitaru-pydantic-ai-migration`, `/kitaru-openai-agents-migration`,
+`/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`, and
+`/kitaru-gemini-interactions-migration`.
 
 ## Installation and usage
 
@@ -67,8 +68,10 @@ marketplace:
 
 Once installed, Claude Code will automatically use the skills based on context.
 You can also invoke them explicitly with `/kitaru-quickstart`,
-`/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`, or
-`/kitaru-openai-agents-migration`.
+`/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`,
+`/kitaru-openai-agents-migration`, `/kitaru-langgraph-migration`,
+`/kitaru-claude-agent-sdk-migration`, or
+`/kitaru-gemini-interactions-migration`.
 
 For project/team installation, add this to your project's
 `.claude/settings.json`:
@@ -95,6 +98,9 @@ cp -R "$tmpdir/kitaru-skills/skills/kitaru-scoping" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-authoring" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-pydantic-ai-migration" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-openai-agents-migration" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-langgraph-migration" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-claude-agent-sdk-migration" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-gemini-interactions-migration" .claude/skills/
 rm -rf "$tmpdir"
 ```
 
@@ -104,7 +110,7 @@ for MCP setup details.
 ### Codex usage
 
 Codex setup depends on the Codex version and local configuration style you use.
-If your Codex environment supports local skills, copy the five
+If your Codex environment supports local skills, copy the eight
 `skills/kitaru-*` directories into the supported Codex skills location or load
 the relevant `SKILL.md` files as explicit project context.
 
@@ -150,6 +156,7 @@ not have a formal skill or plugin system.
 - "How do I inspect executions, waits, logs, and artifacts from the CLI or MCP?"
 - "Help me add Kitaru durability around a LangGraph graph."
 - "Make this Claude Agent SDK invocation durable without promising granular tool replay."
+- "Add Kitaru durability around this Gemini Interactions flow without treating Antigravity internals as replayable."
 
 **PydanticAI migration:**
 - "Migrate this `pydantic_ai.Agent` to `KitaruAgent` and tell me what is direct vs risky."
@@ -162,6 +169,24 @@ not have a formal skill or plugin system.
 - "Choose `runner_call` vs `calls` for this OpenAI Agents SDK workflow and explain the tradeoff."
 - "Add Kitaru durability around this OpenAI Agents approval flow without hiding resume risks."
 - "Update this OpenAI Agents workflow to use `OpenAIRunRequest` and status-aware `OpenAIRunResult` handling."
+
+**LangGraph migration:**
+- "Migrate this `graph.invoke(...)` LangGraph workflow to `KitaruGraphRunner`."
+- "Choose `graph_call` vs middleware-backed `calls` for this LangGraph app and explain what Kitaru can actually replay."
+- "Add Kitaru durability around this LangGraph interrupt flow without replacing the LangGraph checkpointer."
+- "Review this LangChain `create_agent(...)` code and tell me whether `KitaruLangGraphMiddleware` can give safe call-level checkpoints."
+
+**Claude Agent SDK migration:**
+- "Migrate this `claude_agent_sdk.query(...)` workflow to `KitaruClaudeRunner`."
+- "Make this Claude Agent SDK session durable as one invocation checkpoint and flag workspace/file risks."
+- "Review this Claude Agent SDK tool/Bash/MCP setup and tell me what must stay Claude-owned."
+- "Move durable file or API side effects out of the Claude loop and into Kitaru checkpoints."
+
+**Gemini Interactions migration:**
+- "Migrate this `client.interactions.create(...)` code to `KitaruGeminiInteractionsRunner`."
+- "Handle this Gemini Interactions `requires_action` turn at Kitaru flow scope."
+- "Poll an existing Gemini interaction ID with Kitaru instead of creating duplicate background jobs."
+- "Review this Antigravity managed-agent workflow and flag which Google-owned internals are not replayable."
 
 ## Links
 

--- a/skills/kitaru-authoring/SKILL.md
+++ b/skills/kitaru-authoring/SKILL.md
@@ -5,13 +5,14 @@ description: >
   when creating or refactoring Kitaru flows, checkpoints, waits, logging,
   artifacts, tracked LLM calls, replay/resume/retry flows, KitaruClient usage,
   CLI commands, MCP operations, deployments, secrets, or adapter integrations
-  for PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK. Triggers on
-  mentions of kitaru, @flow, @checkpoint, kitaru.wait, kitaru.log,
-  kitaru.save, kitaru.load, KitaruClient, replay, resume, retry,
-  `kitaru executions ...`, MCP tools, `KitaruAgent`, `KitaruRunner`,
-  `KitaruGraphRunner`, `KitaruClaudeRunner`, `wait_for_input`,
-  `wait_for_approval`, `wait_for_interrupt`, or migration from deprecated
-  `wrap(...)`.
+  for PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini
+  Interactions. Triggers on mentions of kitaru, @flow, @checkpoint,
+  kitaru.wait, kitaru.log, kitaru.save, kitaru.load, KitaruClient, replay,
+  resume, retry, `kitaru executions ...`, MCP tools, `KitaruAgent`,
+  `KitaruRunner`, `KitaruGraphRunner`, `KitaruClaudeRunner`,
+  `KitaruGeminiInteractionsRunner`, `GeminiInteractionRequest`,
+  `wait_for_input`, `wait_for_approval`, `wait_for_interrupt`,
+  `requires_action`, Antigravity, or migration from deprecated `wrap(...)`.
 ---
 
 # Kitaru Authoring Skill
@@ -455,6 +456,30 @@ Use `KitaruClaudeRunner` when one Claude SDK invocation should be durable.
 - If a side effect must be durable, make it a separate Kitaru checkpoint after
   Claude returns.
 
+### Gemini Interactions / `KitaruGeminiInteractionsRunner`
+
+Use `KitaruGeminiInteractionsRunner` when one stable Gemini Interactions
+response should be durable. Use the public module `kitaru.adapters.gemini` and
+keep the user-facing adapter name as Gemini Interactions. Treat Antigravity as a
+managed-agent/preset use case, not as the core adapter identity.
+
+- `checkpoint_strategy="interaction"` is the supported boundary: one stable
+  Gemini interaction response becomes one Kitaru checkpoint. Stable statuses are
+  `completed` and `requires_action`.
+- `GeminiInteractionRequest.start(...)`, `.resume(...)`, `.function_result(...)`,
+  `.poll(...)`, and `.antigravity(...)` describe the interaction turn. Poll an
+  existing unfinished interaction by ID instead of creating a duplicate job.
+- Treat `requires_action` as a handoff back to the Kitaru flow. Run local tool
+  work or `kitaru.wait(...)` at flow scope, then send a later
+  `function_result` request.
+- Google-owned hosted tools, MCP, web/code execution, managed-agent steps, and
+  Antigravity sandbox/environment/filesystem internals are not granular Kitaru
+  checkpoints.
+- Use `cache_identity` when project, region, credentials, or client
+  configuration can change what the same logical request means.
+- Review `GeminiInteractionCapturePolicy` before saving raw prompts, provider
+  payloads, steps, or outputs, because those values can contain user data.
+
 ## Common mistakes checklist
 
 - Calling `my_flow(...)` directly instead of `my_flow.run(...)`
@@ -488,6 +513,12 @@ Use `KitaruClaudeRunner` when one Claude SDK invocation should be durable.
 - Treating LangGraph `InMemorySaver` as durable cross-process storage
 - Expecting Claude Agent SDK `KitaruClaudeRunner` to replay Claude-internal Bash,
   MCP, custom-tool, hook, permission, or workspace side effects granularly
+- Treating Gemini hosted tools, MCP, web/code execution, managed-agent steps, or
+  Antigravity sandbox/filesystem internals as granular Kitaru checkpoints
+- Hiding Gemini `requires_action` work inside the provider-owned interaction
+  instead of returning local tool or human work to Kitaru flow scope
+- Assuming Antigravity remote environments provide Kitaru-owned filesystem
+  durability or replayable sandbox state
 - Wrapping every tiny helper in a checkpoint instead of using meaningful replay
   boundaries
 - Constructing adapter wrappers inside hot checkpoint functions when module-scope

--- a/skills/kitaru-claude-agent-sdk-migration/SKILL.md
+++ b/skills/kitaru-claude-agent-sdk-migration/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: kitaru-claude-agent-sdk-migration
+description: >
+  Migrate existing Claude Agent SDK code to Kitaru's Claude Agent SDK adapter.
+  Use when code mentions claude_agent_sdk, claude_agent_sdk.query, query,
+  ClaudeAgentOptions, ClaudeSDKClient, ResultMessage, SystemMessage, session_id,
+  resume, cwd, allowed_tools, Bash, Read, Write, Edit, MCP, hooks, permissions,
+  file checkpointing, transcript, workspace, KitaruClaudeRunner,
+  ClaudeRunRequest, ClaudeRunResult, ClaudeCapturePolicy, checkpoint_strategy,
+  or invocation. Helps classify direct, approximate, and absent mappings, keep
+  Claude-owned internals inside one invocation boundary, and produce a migration
+  report with replay, workspace, session, tool, Bash, MCP, hook, and privacy
+  risks called out.
+---
+
+# Migrate Claude Agent SDK to Kitaru
+
+## What this skill does
+
+Use this skill to inspect existing Claude Agent SDK code and move the safe outer
+execution boundary to Kitaru's `KitaruClaudeRunner`, `ClaudeRunRequest`, and
+`ClaudeRunResult` surfaces.
+
+The output should be conservative:
+
+1. A pattern inventory of the source code.
+2. A migration plan that classifies every important pattern as `direct`,
+   `approximate`, or `absent`.
+3. Migrated or proposed code.
+4. A `MIGRATION_REPORT.md` section or file that names behavior changes and
+   review risks.
+
+Do not promise that Kitaru can see or replay Claude-internal model calls, tool
+calls, Bash commands, MCP calls, hooks, permissions, workspace edits, or file
+checkpointing steps.
+
+## Mental model: Claude runs the loop; Kitaru records one invocation
+
+Claude Agent SDK owns the inner Claude Code-style loop. It decides which files to
+read, which Bash commands to run, which tools or MCP servers to call, which hooks
+fire, how permissions work, and how sessions/files are recorded.
+
+Kitaru changes the doorway you use to enter that loop:
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+runner = KitaruClaudeRunner(
+    name="read_only_reviewer",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Glob", "Grep"]),
+)
+
+@kitaru.flow
+def review(prompt: str) -> str:
+    result = runner.run_sync(ClaudeRunRequest.start(prompt))
+    return result.final_text or ""
+```
+
+Concrete story: Claude starts, reads files, maybe runs tools or Bash, maybe uses
+MCP or hooks, and eventually returns a final result message. Claude owns that
+story. Kitaru records one completed invocation around it.
+
+## When to use this skill
+
+Use it when the user asks to:
+
+- replace `claude_agent_sdk.query(...)` with `KitaruClaudeRunner`;
+- wrap one Claude Agent SDK task in a Kitaru flow;
+- preserve `ClaudeAgentOptions`, `cwd`, `max_turns`, `allowed_tools`, MCP,
+  hooks, permissions, or sessions;
+- handle `session_id` / `resume` through `ClaudeRunRequest.resume(...)`;
+- review file checkpointing, transcripts, workspace file changes, Bash, or MCP
+  under Kitaru replay;
+- choose the only supported strategy: `checkpoint_strategy="invocation"`;
+- produce a migration report for Claude Agent SDK code.
+
+## When not to use this skill
+
+Do not use it to:
+
+- claim Kitaru can checkpoint Claude's internal model/tool/Bash/MCP/hook steps;
+- rewrite the user's code into LangGraph, OpenAI Agents, Gemini Interactions, or
+  PydanticAI;
+- convert Claude file checkpointing into Kitaru workspace snapshots;
+- hide replay, workspace, permission, privacy, or side-effect risks just to
+  produce cleaner code;
+- call `KitaruClaudeRunner` from inside an existing Kitaru checkpoint unless the
+  user explicitly opts into direct execution and accepts replay risk.
+
+## The three mapping types
+
+Classify each source pattern before editing:
+
+- `direct`: Kitaru has a close adapter surface for the same outer behavior.
+  Example: one `query(prompt=...)` task becomes
+  `runner.run_sync(ClaudeRunRequest.start(prompt))`.
+- `approximate`: The code can move, but replay, session, transcript, workspace,
+  capture, or option behavior differs. Example: `ClaudeAgentOptions` becomes
+  fixed `options=` or per-request `options_factory=`.
+- `absent`: There is no safe automatic migration. Example: a plan to checkpoint
+  each Claude Bash command as a Kitaru checkpoint.
+
+Unsupported patterns must not be silently approximated. Add a concrete
+`# TODO(migration): ...` comment near proposed code, list it in the report, and
+explain the redesign needed.
+
+## Migration workflow
+
+1. **Inspect source first.** Find `query(...)`, `ClaudeSDKClient`, options,
+   `allowed_tools`, `cwd`, `max_turns`, sessions, transcripts, MCP servers,
+   hooks, permissions, file checkpointing, Bash, workspace writes, and existing
+   Kitaru decorators.
+2. **Classify every pattern.** Use `references/concept-map.md` and
+   `references/gaps-and-flags.md`. Count direct, approximate, high-risk, and
+   blocked items.
+3. **Choose Kitaru boundaries.** Use only `checkpoint_strategy="invocation"`.
+   One completed Claude SDK invocation becomes one Kitaru checkpoint.
+4. **Present the plan before generating code** when the migration is more than a
+   tiny entrypoint replacement. Name risky tools, workspace writes, and privacy
+   capture decisions before editing.
+5. **Draft migrated code.** Replace raw `query(...)` entrypoints with
+   `KitaruClaudeRunner` plus `ClaudeRunRequest`. Keep Claude options Claude-owned
+   and add explicit capture-policy review.
+6. **Produce `MIGRATION_REPORT.md`.** Include the inventory, chosen boundary,
+   classifications, flags, behavior differences, and verification plan.
+7. **Verify behavior.** Prefer read-only examples with `allowed_tools=[]` or safe
+   read-only tools. If provider execution is not run, say the check was static.
+
+## Pattern detection checklist
+
+Look for:
+
+- `from claude_agent_sdk import query`, `query(...)`, `ClaudeSDKClient`,
+  `client.query(...)`, or `client.receive_response()`.
+- `ClaudeAgentOptions(...)`, `cwd=`, `max_turns=`, `allowed_tools=`,
+  `permission_mode=`, `setting_sources=`, `mcp_servers=`, `hooks=`, or custom
+  agents/skills/plugins.
+- `SystemMessage`, `ResultMessage`, `session_id`, `resume=`,
+  `continue_conversation`, `fork_session`, transcripts, or session stores.
+- `enable_file_checkpointing=True`, `rewind_files(...)`, or checkpoint UUIDs.
+- Built-in tools such as `Read`, `Write`, `Edit`, `Bash`, `Glob`, `Grep`,
+  `WebSearch`, `WebFetch`, or `AskUserQuestion`.
+- Bash commands, filesystem edits, external API calls, database writes, ticket
+  creation, emails, Slack messages, or other side effects triggered by Claude.
+- Existing `@kitaru.flow` or `@kitaru.checkpoint` wrappers.
+- Attempts to configure `calls`, `runner_call`, `model_call`, `tool_call`,
+  `step`, `run`, or granular checkpoints.
+
+## Boundary decision rules
+
+- Keep `claude_agent_sdk` as the agent runtime.
+- Use `KitaruClaudeRunner(name=..., checkpoint_strategy="invocation")`.
+- Use `options=` for fixed `ClaudeAgentOptions` and `options_factory=` when
+  options depend on the `ClaudeRunRequest`.
+- Use `ClaudeRunRequest.start(prompt, cwd=..., max_turns=...)` for fresh tasks.
+- Use `ClaudeRunRequest.resume(prompt, session_id=..., cwd=...)` when the source
+  resumes a specific Claude session.
+- Keep session files/transcripts/file checkpointing Claude-owned. Capture paths
+  or artifacts only when the privacy policy allows it.
+- Move durable file/tool/API side effects into Kitaru-owned flow steps after
+  Claude returns when exact replay matters.
+- Do not run this adapter inside an existing Kitaru checkpoint unless the user
+  explicitly chooses `allow_direct_execution_inside_checkpoint=True` and accepts
+  duplicate-invocation risk.
+
+## Claude Agent SDK migration quick guide
+
+Minimal read-only migration:
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+runner = KitaruClaudeRunner(
+    name="read_only_reviewer",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Glob", "Grep"]),
+)
+
+@kitaru.flow
+def review_code(prompt: str) -> str:
+    result = runner.run_sync(ClaudeRunRequest.start(prompt))
+    return result.final_text or ""
+
+print(review_code.run("Summarize the repository structure.").wait())
+```
+
+For full examples, load `references/code-patterns.md`.
+
+## Gap handling rules
+
+When a pattern is unsafe or unsupported:
+
+1. Do not silently approximate it.
+2. Add a concrete `# TODO(migration): ...` comment near the code if producing
+   code.
+3. Add a report entry with severity `LOW`, `MEDIUM`, `HIGH`, or `BLOCKER`.
+4. Explain the bad outcome the flag prevents. Example: "Claude runs Bash inside
+   the invocation; if Kitaru replays the invocation, the Bash command may run
+   again."
+5. Propose the smallest safe redesign.
+
+## Report requirements
+
+Every non-trivial migration must include or draft `MIGRATION_REPORT.md` with:
+
+- source files reviewed and changed/proposed;
+- classification totals;
+- source pattern inventory;
+- chosen Kitaru invocation boundary;
+- direct translations;
+- approximate translations and caveats;
+- flagged items with severity and required action;
+- Claude-specific notes for options, sessions/resume, workspace effects, file
+  checkpointing, transcripts, MCP, hooks, permissions, Bash/tools, capture
+  policy, and direct execution inside checkpoints;
+- verification plan and whether execution was actually run.
+
+Use `references/report-template.md` when a full report is needed.
+
+## Anti-patterns
+
+Avoid these:
+
+- Using any checkpoint strategy except `"invocation"`.
+- Claiming Kitaru replays Claude-internal model/tool/Bash/MCP/hook steps.
+- Treating Claude file checkpointing as Kitaru checkpointing.
+- Ignoring workspace edits or Bash side effects.
+- Returning raw SDK message objects from Kitaru checkpoints.
+- Passing API keys, prompts, transcripts, file paths, or user data as Kitaru
+  metadata without a privacy review.
+- Calling `runner.run_sync(...)` from inside an active event loop.
+- Calling the runner inside another Kitaru checkpoint without explicit opt-in.
+
+## References
+
+Load only the reference file needed for the current task:
+
+- `references/concept-map.md` — source-to-target mapping table and
+  classification guidance.
+- `references/code-patterns.md` — import-complete migration examples.
+- `references/gaps-and-flags.md` — severity definitions, upstream assumptions,
+  and must-flag patterns.
+- `references/report-template.md` — Claude Agent SDK-specific migration report
+  template.
+
+Kitaru source references:
+
+- Kitaru Claude Agent SDK adapter docs:
+  `kitaru/docs/content/docs/adapters/claude-agent-sdk.mdx`
+- Adapter exports:
+  `kitaru/src/kitaru/adapters/claude_agent_sdk/__init__.py`
+- Adapter example:
+  `kitaru/examples/integrations/claude_agent_sdk_agent/README.md`

--- a/skills/kitaru-claude-agent-sdk-migration/references/code-patterns.md
+++ b/skills/kitaru-claude-agent-sdk-migration/references/code-patterns.md
@@ -1,0 +1,239 @@
+# Claude Agent SDK Migration Code Patterns
+
+These examples are intentionally import-complete. Copy the shape, then adapt
+names, prompts, `cwd`, options, permissions, and capture settings to the source
+project. They are not provider-live smoke tests.
+
+## 1. Minimal `query(...)` replacement
+
+Source:
+
+```python
+import asyncio
+
+from claude_agent_sdk import ClaudeAgentOptions, ResultMessage, query
+
+async def main() -> None:
+    async for message in query(
+        prompt="Summarize this repository.",
+        options=ClaudeAgentOptions(allowed_tools=["Read", "Glob", "Grep"]),
+    ):
+        if isinstance(message, ResultMessage):
+            print(message.result)
+
+asyncio.run(main())
+```
+
+Target:
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+runner = KitaruClaudeRunner(
+    name="repo_summarizer",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Glob", "Grep"]),
+)
+
+@kitaru.flow
+def summarize_repo(prompt: str) -> str:
+    result = runner.run_sync(ClaudeRunRequest.start(prompt))
+    return result.final_text or ""
+
+handle = summarize_repo.run("Summarize this repository.")
+print(handle.wait())
+```
+
+## 2. Async Kitaru runner
+
+Use this when the caller is already async.
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+runner = KitaruClaudeRunner(
+    name="async_reviewer",
+    options=ClaudeAgentOptions(allowed_tools=["Read", "Glob", "Grep"]),
+)
+
+async def review_async(prompt: str) -> str:
+    result = await runner.run(ClaudeRunRequest.start(prompt))
+    return result.final_text or ""
+```
+
+Do not keep `run_sync(...)` inside an active event loop.
+
+## 3. Request-specific options with `options_factory`
+
+Use a factory when fields vary per request. Keep the factory deterministic and
+avoid capturing secrets or live clients.
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import (
+    ClaudeRunRequest,
+    KitaruClaudeRunner,
+)
+
+
+def options_for_request(request: ClaudeRunRequest) -> ClaudeAgentOptions:
+    allowed_tools = ["Read", "Glob", "Grep"]
+    if request.metadata.get("allow_edits") is True:
+        allowed_tools = ["Read", "Glob", "Grep", "Edit"]
+    return ClaudeAgentOptions(
+        allowed_tools=allowed_tools,
+        cwd=request.cwd,
+    )
+
+runner = KitaruClaudeRunner(
+    name="request_sensitive_claude",
+    options_factory=options_for_request,
+)
+
+@kitaru.flow
+def run_task(prompt: str, cwd: str, allow_edits: bool) -> str:
+    request = ClaudeRunRequest.start(
+        prompt,
+        cwd=cwd,
+        metadata={"allow_edits": allow_edits},
+    )
+    result = runner.run_sync(request)
+    return result.final_text or ""
+```
+
+If `allow_edits=True`, flag workspace side effects for human review.
+
+## 4. Resume a Claude session
+
+Source shape:
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions, query
+
+async for message in query(
+    prompt="Continue the refactor.",
+    options=ClaudeAgentOptions(resume=session_id),
+):
+    ...
+```
+
+Target shape:
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+def options_for_resume(request: ClaudeRunRequest) -> ClaudeAgentOptions:
+    return ClaudeAgentOptions(
+        allowed_tools=["Read", "Glob", "Grep"],
+        cwd=request.cwd,
+        resume=request.resume_session_id,
+        max_turns=request.max_turns,
+    )
+
+
+runner = KitaruClaudeRunner(
+    name="claude_session_runner",
+    options_factory=options_for_resume,
+)
+
+@kitaru.flow
+def continue_session(
+    prompt: str,
+    session_id: str,
+    cwd: str,
+    max_turns: int,
+) -> str:
+    request = ClaudeRunRequest.resume(
+        prompt,
+        session_id=session_id,
+        cwd=cwd,
+        max_turns=max_turns,
+    )
+    result = runner.run_sync(request)
+    return result.final_text or ""
+```
+
+Report caveat: Claude session files/history remain Claude-owned. Session
+resume migrations should generally use `options_factory`, because request-scoped
+fields such as `cwd`, `resume_session_id`, and `max_turns` must be copied into
+`ClaudeAgentOptions` for each request. Preserve `cwd` and session storage, or
+pass needed state explicitly into a fresh prompt.
+
+## 5. Capture policy review
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import (
+    ClaudeCapturePolicy,
+    KitaruClaudeRunner,
+)
+
+runner = KitaruClaudeRunner(
+    name="privacy_reviewed_claude",
+    options=ClaudeAgentOptions(allowed_tools=[]),
+    capture=ClaudeCapturePolicy(
+        emit_events=True,
+        save_prompt=False,
+        save_messages=False,
+        save_transcript_file=False,
+        save_options_manifest=True,
+        save_final_output=True,
+        save_usage=True,
+        redact_options_manifest=True,
+    ),
+)
+```
+
+Adjust field names against the current Kitaru adapter if the capture policy has
+changed. The migration report should say exactly what is saved.
+
+## 6. Workspace side-effect warning
+
+This is a possible migration shape, but it must be flagged when tools can write.
+
+```python
+import kitaru
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner, ClaudeRunRequest
+
+runner = KitaruClaudeRunner(
+    name="editing_claude",
+    options=ClaudeAgentOptions(
+        allowed_tools=["Read", "Edit", "Write", "Bash"],
+        permission_mode="acceptEdits",
+    ),
+)
+
+@kitaru.flow
+def edit_code(prompt: str, cwd: str) -> str:
+    # TODO(migration): Claude can edit files and run Bash inside this single
+    # invocation. If Kitaru replays it, those effects may happen again. Add
+    # idempotency, validation, or narrower tools before production use.
+    result = runner.run_sync(ClaudeRunRequest.start(prompt, cwd=cwd))
+    return result.final_text or ""
+```
+
+## 7. Keep file checkpointing Claude-owned
+
+```python
+from claude_agent_sdk import ClaudeAgentOptions
+from kitaru.adapters.claude_agent_sdk import KitaruClaudeRunner
+
+runner = KitaruClaudeRunner(
+    name="file_checkpointing_claude",
+    options=ClaudeAgentOptions(
+        enable_file_checkpointing=True,
+        permission_mode="acceptEdits",
+        extra_args={"replay-user-messages": None},
+    ),
+)
+```
+
+Report caveat: Claude file checkpointing can rewind selected file changes, but
+it is not Kitaru checkpointing. It does not make Bash writes or arbitrary
+workspace state Kitaru-durable.

--- a/skills/kitaru-claude-agent-sdk-migration/references/concept-map.md
+++ b/skills/kitaru-claude-agent-sdk-migration/references/concept-map.md
@@ -1,0 +1,64 @@
+# Claude Agent SDK to Kitaru Concept Map
+
+Use this map while classifying source code. The safe migration story is simple:
+Claude Agent SDK owns the inner Claude Code-style loop; Kitaru records one outer
+SDK invocation.
+
+## Mapping labels
+
+- `direct`: Kitaru has a close adapter surface for the same outer behavior.
+- `approximate`: Migration is possible, but replay, workspace, session,
+  transcript, option, or capture behavior differs.
+- `absent`: No safe automatic migration. The code needs redesign or explicit
+  human review before migration.
+
+## Core concepts
+
+| Claude Agent SDK source pattern | Kitaru target pattern | Mapping | Notes |
+|---|---|---:|---|
+| `claude_agent_sdk.query(prompt=..., options=...)` | `runner.run/run_sync(ClaudeRunRequest.start(prompt))` | `direct` for one invocation | Kitaru changes the outer doorway, not Claude's loop. |
+| `ClaudeSDKClient(...).query(...)` | `KitaruClaudeRunner.run(...)` for one task | `approximate` | Client streaming/control surfaces may not map exactly; preserve only supportable invocation behavior. |
+| `ClaudeAgentOptions(...)` fixed for all runs | `KitaruClaudeRunner(options=...)` | `direct` | Claude options pass through to the SDK invocation. |
+| Options vary by request | `options_factory=lambda request: ClaudeAgentOptions(...)` | `approximate` | Factory runs per Kitaru request; avoid volatile captures. |
+| `cwd=` in options or query | `ClaudeRunRequest.start(..., cwd=...)` or options | `direct` | Keep the path materialized. Do not pass checkpoint output handles. |
+| `max_turns=` | `ClaudeRunRequest.start(..., max_turns=...)` | `direct` | Must be positive when provided. |
+| Session ID captured from `SystemMessage`/`ResultMessage` | `ClaudeRunResult.session_id` | `direct` | Result envelope can expose the session ID. |
+| `ClaudeAgentOptions(resume=session_id)` | `ClaudeRunRequest.resume(prompt, session_id=...)` plus options as needed | `approximate` | Claude session history remains SDK-owned and local/session-store dependent. |
+| `ClaudeSDKClient` multi-turn chat | Separate Kitaru invocations with resume IDs, or leave client flow raw | `approximate` | Kitaru records invocation boundaries, not every streamed message. |
+| Built-in tools: `Read`, `Write`, `Edit`, `Bash`, etc. | Same `allowed_tools` / permissions in Claude options | `approximate` | Claude executes the tools inside the invocation. Review side effects. |
+| MCP servers | Same `mcp_servers` options | `approximate` | MCP calls remain Claude-owned inside the invocation. |
+| Hooks | Same `hooks` options | `approximate` | Hooks can have side effects and are not separate Kitaru checkpoints. |
+| Permissions / approval modes | Same Claude options | `approximate` | Kitaru does not replace Claude's permission system. |
+| File checkpointing / `rewind_files(...)` | Leave Claude-owned; optionally capture IDs/paths as metadata/artifacts | `approximate` | It rewinds selected workspace files, not Kitaru execution state. |
+| Transcripts / JSONL session files | Capture path or artifact only after privacy review | `approximate` | Transcripts can contain prompts, file paths, commands, and tool outputs. |
+| `checkpoint_strategy="invocation"` | One Kitaru checkpoint around `query(...)` | `direct` | Only supported strategy. |
+| `calls`, `runner_call`, `granular`, `model_call`, `tool_call`, `step`, `run` | No Kitaru mapping | `absent` | Kitaru intentionally rejects granular Claude-internal strategies. |
+| Runner call inside existing Kitaru checkpoint | Move to flow scope, or explicit direct-execution opt-in | `absent` unless user accepts risk | Replay can duplicate the whole Claude invocation. |
+| `runner.run_sync(...)` inside active event loop | `await runner.run(...)` | `absent` for sync shape | Do not preserve sync call in async code. |
+| Workspace/file/API side effects | Application-owned idempotency or separate Kitaru flow steps | `approximate` or `absent` | Claude may repeat those effects if Kitaru replays the invocation. |
+| Raw SDK messages returned from checkpoints | `ClaudeRunResult` or simple values | `absent until redesigned` | Raw message objects may not be serializable or privacy-safe. |
+| Secrets in prompt/metadata | Use environment/secrets; keep out of durable metadata | `absent until fixed` | Kitaru artifacts and metadata may be retained. |
+
+## Boundary decision guide
+
+Use `invocation` when:
+
+- one Claude task should be durable as a whole;
+- the source uses `query(...)` or a single `ClaudeSDKClient.query(...)` task;
+- tools/Bash/MCP/hooks are acceptable as Claude-owned internal behavior;
+- the result envelope and optional captured artifacts are enough.
+
+Do not use this adapter when:
+
+- the user requires Kitaru to checkpoint every Claude tool/Bash/MCP step;
+- replaying the whole invocation would repeat destructive file/API effects;
+- session files or workspace changes cannot be made durable or idempotent enough
+  for the target deployment.
+
+## What Kitaru does not own
+
+Kitaru does not own Claude's model calls, tool execution, Bash execution, MCP
+calls, hooks, permissions, session JSONL files, workspace edits, or file
+checkpointing/rewind mechanics. If the source depends on those internals being
+replayed as separate Kitaru units, mark the mapping `absent` or `approximate` and
+explain the boundary clearly.

--- a/skills/kitaru-claude-agent-sdk-migration/references/gaps-and-flags.md
+++ b/skills/kitaru-claude-agent-sdk-migration/references/gaps-and-flags.md
@@ -1,0 +1,153 @@
+# Claude Agent SDK Migration Gaps and Flags
+
+Use this file when deciding whether a migration is safe to apply automatically.
+The rule is: if replay, workspace, session, transcript, permission, side effect,
+secret, or SDK resume behavior may change, make that visible in code comments
+and in the migration report.
+
+## Upstream docs checked
+
+Checked on 2026-06-04 against current official docs:
+
+- Agent SDK overview: https://platform.claude.com/docs/en/agent-sdk/overview
+- Python SDK reference: https://platform.claude.com/docs/en/agent-sdk/python
+- Sessions: https://platform.claude.com/docs/en/agent-sdk/sessions
+- Hooks: https://platform.claude.com/docs/en/agent-sdk/hooks
+- MCP: https://platform.claude.com/docs/en/agent-sdk/mcp
+- File checkpointing: https://platform.claude.com/docs/en/agent-sdk/file-checkpointing
+
+Assumptions recorded here: `query(...)`, `ClaudeAgentOptions`, and
+`ClaudeSDKClient` remain the main Python surfaces; sessions are Claude-owned and
+resume by ID; file checkpointing rewinds selected file changes, not conversation
+or Kitaru execution state; tools, Bash, MCP, hooks, and permissions execute
+inside the Claude invocation.
+
+## Severity levels
+
+| Severity | Meaning | Required action |
+|---|---|---|
+| `LOW` | Cosmetic or documentation-only difference. | Migrate and mention in report. |
+| `MEDIUM` | Behavior probably preserved, but settings or observability differ. | Migrate with caveat and verification step. |
+| `HIGH` | Replay, workspace, session, side-effect, privacy, or runtime behavior may change. | Require human review before applying or mark partial migration. |
+| `BLOCKER` | Migration would be unsafe or impossible without source redesign. | Do not auto-migrate; generate redesign note and report entry. |
+
+## Must-flag patterns
+
+### Unsupported granular checkpoint strategies
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** `checkpoint_strategy="calls"`, `"runner_call"`, `"granular"`,
+  `"model_call"`, `"tool_call"`, `"step"`, or `"run"`.
+- **Why it matters:** Kitaru's Claude adapter only supports one invocation
+  boundary. Claude-internal steps are not Kitaru checkpoints.
+- **Action:** use `checkpoint_strategy="invocation"` or redesign.
+
+### Runner call inside existing Kitaru checkpoint
+
+- **Severity:** `BLOCKER` unless the user explicitly accepts direct execution
+  risk.
+- **Pattern:** `KitaruClaudeRunner.run/run_sync(...)` called from a
+  `@kitaru.checkpoint` body.
+- **Why it matters:** replaying the outer checkpoint may run the whole Claude
+  invocation again: files changed twice, Bash run twice, API called twice.
+- **Action:** move the runner call to flow scope, or set
+  `allow_direct_execution_inside_checkpoint=True` only with an explicit report
+  warning.
+
+### Bash or write tools without idempotency
+
+- **Severity:** `HIGH`; `BLOCKER` for destructive/customer-visible effects.
+- **Pattern:** `allowed_tools` includes `Bash`, `Write`, `Edit`, or tools/MCP
+  servers that mutate external systems.
+- **Why it matters:** Kitaru replays the invocation as one unit. Claude may run
+  the same command or edit again.
+- **Action:** restrict tools, add idempotency/safety checks, or move critical
+  side effects into reviewed Kitaru-owned flow steps after Claude returns.
+
+### File checkpointing treated as Kitaru checkpointing
+
+- **Severity:** `HIGH`.
+- **Pattern:** migration claims `enable_file_checkpointing=True` gives Kitaru
+  durable workspace snapshots.
+- **Why it matters:** Claude file checkpointing tracks selected file edits for
+  rewind; it does not rewind the Claude conversation or Kitaru execution state,
+  and Bash file writes are not covered by Claude's file checkpointing limits.
+- **Action:** describe file checkpointing as Claude-owned. Capture IDs/paths only
+  if useful and privacy-safe.
+
+### Session resume without stable `cwd` / session storage
+
+- **Severity:** `HIGH`.
+- **Pattern:** `resume=session_id` or `ClaudeRunRequest.resume(...)` without
+  checking that the session exists under the same working directory or shared
+  session store.
+- **Why it matters:** Claude session lookup can miss the old transcript and start
+  without expected context.
+- **Action:** preserve `cwd`, mirror session files/shared storage if needed, or
+  pass needed state explicitly into a fresh prompt.
+
+### Transcript or message capture without privacy review
+
+- **Severity:** `MEDIUM`, or `HIGH` for customer data, source code, secrets,
+  incident data, or regulated workflows.
+- **Pattern:** migration enables broad transcript/message/output capture by
+  default.
+- **Why it matters:** transcripts can contain prompts, tool arguments, command
+  output, file paths, and user data.
+- **Action:** choose an explicit `ClaudeCapturePolicy(...)` and record what is
+  saved.
+
+### Hooks with side effects
+
+- **Severity:** `HIGH`.
+- **Pattern:** hooks write audit files, send webhooks, update databases, or block
+ /modify tool calls in ways the migration does not inspect.
+- **Why it matters:** hooks run inside the Claude invocation and may run again on
+  replay.
+- **Action:** make hooks idempotent, move durable side effects outside the
+  invocation, or keep the migration plan-only.
+
+### `ClaudeSDKClient` streaming/control flow mapped as if identical
+
+- **Severity:** `MEDIUM` to `HIGH`.
+- **Pattern:** source depends on streamed intermediate messages,
+  `receive_response()`, progress monitoring, or interactive client lifecycle.
+- **Why it matters:** Kitaru runner records one invocation result envelope, not
+  arbitrary client streaming behavior.
+- **Action:** migrate only the one-task invocation, or leave complex streaming
+  client code raw and report the difference.
+
+### `run_sync` inside an active event loop
+
+- **Severity:** `BLOCKER` for preserving sync shape.
+- **Pattern:** async application code calls sync query/runner methods.
+- **Why it matters:** keeping sync execution preserves the event-loop bug.
+- **Action:** convert caller to `await runner.run(...)`.
+
+### Secrets in prompt, metadata, logs, or transcripts
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** API keys/tokens are passed as prompts, request metadata, or logged
+  outputs.
+- **Why it matters:** Kitaru may store request metadata and artifacts durably.
+- **Action:** use environment variables or a secret manager; remove secrets from
+  prompts, metadata, and logs.
+
+## Required report entry shape
+
+```markdown
+- Severity: HIGH
+- Source location: path/to/agent.py:123
+- Pattern: `allowed_tools=["Bash", "Edit"]` inside one Kitaru invocation
+- Migration action: migrated outer invocation only
+- Why it matters: replay may run the same Bash command or edit again
+- Required human decision: restrict tools or add idempotent workspace checks
+```
+
+## Code comment shape
+
+```python
+# TODO(migration): Claude can run Bash inside this invocation. If Kitaru replays
+# the invocation, the command may run again. Add idempotency or restrict tools
+# before relying on this boundary for production replay.
+```

--- a/skills/kitaru-claude-agent-sdk-migration/references/report-template.md
+++ b/skills/kitaru-claude-agent-sdk-migration/references/report-template.md
@@ -1,0 +1,162 @@
+# Migration Report: Claude Agent SDK to Kitaru Adapter
+
+Use this template for `MIGRATION_REPORT.md` or for a report section in the final
+answer when the user does not want a file written.
+
+## Summary
+
+- Source framework: Claude Agent SDK
+- Target adapter: `kitaru.adapters.claude_agent_sdk.KitaruClaudeRunner`
+- Source files reviewed:
+  - `[path]`
+- Files changed or proposed:
+  - `[path]`
+- Migration status: `[complete / partial / plan only / blocked]`
+- Classification totals:
+  - Direct: `[n]`
+  - Approximate: `[n]`
+  - Absent: `[n]`
+  - Flagged: `[n]`
+  - Blocked: `[n]`
+
+## Source Pattern Inventory
+
+| Source location | Pattern found | Classification | Severity | Notes |
+|---|---|---|---|---|
+| `[file:line]` | `query(prompt=...)` | `direct` | `LOW` | Replaced with `KitaruClaudeRunner` invocation. |
+| `[file:line]` | `[pattern]` | `[direct / approximate / absent]` | `[LOW / MEDIUM / HIGH / BLOCKER]` | `[concrete note]` |
+
+## Chosen Kitaru Boundaries
+
+Describe the save points in plain language.
+
+Example:
+
+- The Claude Agent SDK remains the agent runtime.
+- `KitaruClaudeRunner` is constructed once with a stable name.
+- The adapter uses `checkpoint_strategy="invocation"`, so one completed
+  `claude_agent_sdk.query(...)` invocation becomes one Kitaru checkpoint.
+- Claude tools, Bash, MCP, hooks, permissions, sessions, transcripts, and file
+  checkpointing remain Claude-owned inside that invocation.
+
+## Direct Translations
+
+| Source | Target | Why direct |
+|---|---|---|
+| `query(prompt=prompt, options=options)` | `runner.run_sync(ClaudeRunRequest.start(prompt))` | Same one-task SDK invocation; Kitaru changes the outer doorway. |
+| `[source]` | `[target]` | `[reason]` |
+
+## Approximate Translations
+
+| Source | Target | Behavior difference | Verification step |
+|---|---|---|---|
+| `ClaudeAgentOptions(resume=session_id)` | `ClaudeRunRequest.resume(prompt, session_id=...)` | Session history remains Claude-owned and depends on cwd/session storage. | Resume a known session from the target environment. |
+| `[source]` | `[target]` | `[difference]` | `[step]` |
+
+## Flagged for Human Review
+
+| Severity | Source location | Issue | What could break | Required action |
+|---|---|---|---|---|
+| `HIGH` | `[file:line]` | `[issue]` | `[duplicate Bash/file/API side effect / lost session / sensitive transcript / etc.]` | `[review or redesign step]` |
+
+## Adapter-Specific Notes
+
+### Runner identity and strategy
+
+- Runner name: `[name]`
+- Chosen strategy: `invocation`
+- Unsupported strategies found: `[none/list]`
+
+### Options and permissions
+
+- Fixed `options=` used: `[yes/no]`
+- `options_factory=` used: `[yes/no]`
+- `allowed_tools`: `[list]`
+- Permission mode: `[mode/default]`
+- Risk note: `[what Claude can do inside the invocation]`
+
+### Sessions and resume
+
+- Captures `session_id`: `[yes/no]`
+- Uses resume: `[yes/no]`
+- `cwd` stable across resume: `[yes/no/unknown]`
+- Session storage caveat:
+  - `[local session file / shared store / explicitly passed state]`
+
+### Workspace, Bash, and file checkpointing
+
+- File-writing tools enabled: `[yes/no/list]`
+- Bash enabled: `[yes/no]`
+- File checkpointing enabled: `[yes/no]`
+- Rewind IDs captured: `[yes/no/not needed]`
+- Replay consequence:
+  - `[what may run again if Kitaru replays the whole invocation]`
+
+### MCP, hooks, and custom tools
+
+- MCP servers found: `[yes/no/list]`
+- Hooks found: `[yes/no/list]`
+- Custom tools/subagents/skills/plugins found: `[yes/no/list]`
+- Side effects reviewed: `[yes/no]`
+
+### Capture and privacy policy
+
+- Capture policy configured: `[yes/no]`
+- Messages saved: `[yes/no/default]`
+- Transcript saved: `[yes/no/default]`
+- Output saved: `[yes/no/default]`
+- Options manifest saved: `[yes/no/default]`
+- Sensitive data risk: `[none known / needs review]`
+
+## Behavioral Differences
+
+Explain concrete differences introduced by the migration.
+
+Examples:
+
+- "The source previously called `claude_agent_sdk.query(...)` directly. The
+  migrated code calls the same SDK through `KitaruClaudeRunner`, so Kitaru can
+  record one completed invocation result."
+- "Claude file checkpointing remains Claude-owned. Kitaru does not snapshot the
+  workspace or rewind files."
+- "Bash and MCP calls happen inside the invocation. If Kitaru replays the
+  invocation, those effects may happen again unless the project makes them safe."
+
+## What Is Not Migrated
+
+| Item | Reason | Recommended redesign |
+|---|---|---|
+| `[item]` | `[why absent or unsafe]` | `[redesign]` |
+
+## Verification Plan
+
+- Static checks:
+  - `[imports resolve / strategy is invocation / no runner call inside checkpoint]`
+- Read-only dry-run:
+  - `[allowed_tools=[] or Read/Glob/Grep command]`
+- Provider-backed run:
+  - `[command or not run because credentials unavailable]`
+- Kitaru behavior checks:
+  - Confirm execution appears in dashboard or `kitaru executions list`.
+  - Confirm one invocation checkpoint appears.
+  - Confirm resume works if sessions are migrated.
+  - Confirm replay does not duplicate unsafe workspace or external side effects.
+
+## Docs and Reference Links
+
+- Kitaru Claude Agent SDK adapter docs:
+  `kitaru/docs/content/docs/adapters/claude-agent-sdk.mdx`
+- Kitaru Claude adapter exports:
+  `kitaru/src/kitaru/adapters/claude_agent_sdk/__init__.py`
+- Skill references:
+  - `skills/kitaru-claude-agent-sdk-migration/references/concept-map.md`
+  - `skills/kitaru-claude-agent-sdk-migration/references/code-patterns.md`
+  - `skills/kitaru-claude-agent-sdk-migration/references/gaps-and-flags.md`
+
+## Recommended Next Steps
+
+1. `[Run read-only SDK smoke test / provider-backed smoke test]`
+2. `[Review HIGH/BLOCKER workspace, Bash, MCP, hook, and transcript items]`
+3. `[Decide whether options should be fixed or request-specific]`
+4. `[Add project-specific tests for replay and side effects]`
+5. `[Update user-facing docs or examples if this migration changes public behavior]`

--- a/skills/kitaru-gemini-interactions-migration/SKILL.md
+++ b/skills/kitaru-gemini-interactions-migration/SKILL.md
@@ -1,0 +1,257 @@
+---
+name: kitaru-gemini-interactions-migration
+description: >
+  Migrate existing Gemini Interactions, Google GenAI, and Antigravity managed
+  agent code to Kitaru's Gemini Interactions adapter. Use when code mentions
+  google.genai, genai.Client, client.interactions.create, client.interactions.get,
+  Interaction, interaction_id, previous_interaction_id, requires_action,
+  function_call, function_result, background, store, poll, steps, output_text,
+  Antigravity, managed agents, environment, Vertex, API key,
+  KitaruGeminiInteractionsRunner, GeminiInteractionRequest,
+  GeminiInteractionResult, GeminiInteractionCapturePolicy, or cache_identity.
+  Helps classify direct, approximate, and absent mappings, preserve Google-owned
+  hosted interaction internals, handle requires_action and polling safely, and
+  produce a migration report.
+---
+
+# Migrate Gemini Interactions to Kitaru
+
+## What this skill does
+
+Use this skill to inspect existing Gemini Interactions / Google GenAI code and
+move the safe outer interaction boundary to Kitaru's `kitaru.adapters.gemini`
+surfaces.
+
+The output should be conservative:
+
+1. A source pattern inventory.
+2. A migration plan that classifies each important pattern as `direct`,
+   `approximate`, or `absent`.
+3. Migrated or proposed code using `KitaruGeminiInteractionsRunner`,
+   `GeminiInteractionRequest`, `GeminiInteractionResult`, and capture policy.
+4. A `MIGRATION_REPORT.md` section or file that names replay, polling,
+   `requires_action`, hosted-tool, Antigravity, environment, region, credential,
+   and privacy risks.
+
+Use the user-facing name **Gemini Interactions**. Treat Antigravity as an
+important managed-agent/preset use case, not as the primary adapter identity.
+
+## Mental model: Google owns the hosted runtime; Kitaru records one stable response
+
+Google owns the hosted interaction runtime: model/agent execution, hosted tools,
+MCP, web/code execution, Antigravity sandbox/environment internals, background
+jobs, and server-side interaction history.
+
+Kitaru records one stable Gemini Interactions response with
+`checkpoint_strategy="interaction"`. Stable means `completed` or
+`requires_action`.
+
+Concrete story: the app sends an interaction request. Google may think, browse,
+call hosted tools, use an Antigravity environment, or ask for a local function
+result. Kitaru cannot see all of that internal work. Kitaru records the stable
+response that comes back. If the response says `requires_action`, the work
+returns to your Kitaru flow: run the local tool or ask a human, then send a later
+`function_result` request.
+
+## When to use this skill
+
+Use it when the user asks to:
+
+- replace `client.interactions.create(...)` with
+  `KitaruGeminiInteractionsRunner.run/run_sync(...)`;
+- migrate `client.interactions.get(...)` polling to `GeminiInteractionRequest.poll(...)`;
+- preserve `previous_interaction_id` with `GeminiInteractionRequest.resume(...)`;
+- migrate function-result turns with `GeminiInteractionRequest.function_result(...)`;
+- handle `requires_action` at Kitaru flow scope;
+- review `background`, `store`, `steps`, `output_text`, hosted tools, MCP,
+  Google Search, code execution, web tools, Antigravity, managed agents, Vertex,
+  API keys, regions, environments, or `cache_identity`;
+- produce a migration report for Gemini Interactions code.
+
+## When not to use this skill
+
+Do not use it to:
+
+- migrate classic `generateContent` code unless the user is explicitly moving it
+  to Gemini Interactions first;
+- claim Kitaru can checkpoint Google-owned hosted tools, MCP, web/code
+  execution, background internals, or Antigravity sandbox steps;
+- hide `requires_action` work inside the provider-owned interaction instead of
+  returning it to Kitaru flow scope;
+- treat in-progress/background jobs as successful checkpoint outputs;
+- make Antigravity look like the core adapter identity.
+
+## The three mapping types
+
+Classify each source pattern before editing:
+
+- `direct`: Kitaru has a close adapter surface for the same outer behavior.
+  Example: `client.interactions.create(model=..., input=...)` becomes
+  `runner.run_sync(GeminiInteractionRequest.start(input, model=...))`.
+- `approximate`: The migration is possible, but replay, polling, state,
+  environment, capture, or hosted-tool behavior differs. Example: hosted tool
+  steps remain Google-owned and are captured only as response summaries/artifacts.
+- `absent`: There is no safe automatic migration. Example: a plan to replay each
+  Antigravity file operation as a Kitaru checkpoint.
+
+Unsupported patterns must not be silently approximated. Add a concrete
+`# TODO(migration): ...` comment near proposed code, list it in the report, and
+explain the redesign needed.
+
+## Migration workflow
+
+1. **Inspect source first.** Find `genai.Client`, `client.interactions.create`,
+   `get`, `previous_interaction_id`, `background`, `store`, function calls,
+   function results, status checks, Antigravity/managed agents, environments,
+   Vertex/API-key configuration, and existing Kitaru decorators.
+2. **Classify every pattern.** Use `references/concept-map.md` and
+   `references/gaps-and-flags.md`. Count direct, approximate, high-risk, and
+   blocked items.
+3. **Choose Kitaru boundaries.** Use only `checkpoint_strategy="interaction"`.
+   One stable Gemini Interactions response becomes one Kitaru checkpoint.
+4. **Present the plan before generating code** when the migration is more than a
+   tiny entrypoint replacement. Name hosted runtime limits, polling behavior,
+   and privacy capture decisions before editing.
+5. **Draft migrated code.** Replace raw interactions entrypoints with
+   `KitaruGeminiInteractionsRunner` plus `GeminiInteractionRequest`. Add status
+   handling for `completed`, `requires_action`, and non-stable statuses.
+6. **Produce `MIGRATION_REPORT.md`.** Include the inventory, chosen boundary,
+   classifications, flags, behavior differences, and verification plan.
+7. **Verify behavior.** Prefer static/import checks. If API-key/Vertex access is
+   unavailable, say the check was static only.
+
+## Pattern detection checklist
+
+Look for:
+
+- `from google import genai`, `genai.Client(...)`, `client.interactions.create`,
+  `client.interactions.get`, or `Interaction` objects.
+- `model=...`, `agent=...`, `environment=...`, `tools=...`,
+  `system_instruction=...`, `generation_config=...`, `agent_config=...`,
+  `response_format=...`, or `response_mime_type=...`.
+- `previous_interaction_id`, `interaction.id`, `interaction_id`, `background`,
+  `store`, `poll`, webhooks, or retry loops.
+- `status`, `requires_action`, `function_call`, `function_result`, `call_id`,
+  `steps`, `output_text`, and manual local tool execution.
+- Antigravity agent IDs/presets, managed agents, remote environments, sandbox
+  files, and environment IDs.
+- API-key vs Vertex/ADC setup, project, region/location, and client factories.
+- Raw interaction payload capture, request manifests, logs, prompts, tool args,
+  generated files, or user data.
+- Existing `@kitaru.flow` or `@kitaru.checkpoint` wrappers.
+
+## Boundary decision rules
+
+- Keep Gemini Interactions as the hosted runtime.
+- Use `KitaruGeminiInteractionsRunner(name=..., checkpoint_strategy="interaction")`.
+- Use `GeminiInteractionRequest.start(...)` for new interactions.
+- Use `GeminiInteractionRequest.resume(...)` for `previous_interaction_id` turns.
+- Use `GeminiInteractionRequest.function_result(...)` to answer a prior
+  `requires_action` function call.
+- Use `GeminiInteractionRequest.poll(interaction_id=...)` to fetch an existing
+  background interaction. Do not create duplicate jobs to check progress.
+- Preserve the `model=` vs `agent=` distinction. Set exactly one.
+- Use `.antigravity(...)` for Antigravity managed-agent requests when that preset
+  fits, but report that Antigravity internals remain Google-owned.
+- Add `cache_identity` when the same logical request might run under different
+  projects, regions, credentials, clients, or environment configuration.
+- Treat statuses other than `completed` and `requires_action` as not safely
+  checkpointable final outputs.
+
+## Gemini Interactions migration quick guide
+
+Minimal model interaction:
+
+```python
+import kitaru
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="gemini_writer")
+
+@kitaru.flow
+def write_summary(topic: str) -> str:
+    result = runner.run_sync(
+        GeminiInteractionRequest.start(
+            f"Write a short summary of {topic}.",
+            model="gemini-3.5-flash",
+        )
+    )
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {result.status!r}")
+    return result.output_text or ""
+```
+
+For full examples, load `references/code-patterns.md`.
+
+## Gap handling rules
+
+When a pattern is unsafe or unsupported:
+
+1. Do not silently approximate it.
+2. Add a concrete `# TODO(migration): ...` comment near the code if producing
+   code.
+3. Add a report entry with severity `LOW`, `MEDIUM`, `HIGH`, or `BLOCKER`.
+4. Explain the bad outcome the flag prevents. Example: "creating a new
+   background interaction while polling would start duplicate provider work."
+5. Propose the smallest safe redesign.
+
+## Report requirements
+
+Every non-trivial migration must include or draft `MIGRATION_REPORT.md` with:
+
+- source files reviewed and changed/proposed;
+- classification totals;
+- source pattern inventory;
+- chosen Kitaru interaction boundary;
+- direct translations;
+- approximate translations and caveats;
+- flagged items with severity and required action;
+- Gemini-specific notes for stable statuses, `requires_action`, function
+  results, polling/background jobs, model vs agent targets, Antigravity,
+  environments, Vertex/API-key/region/client configuration, `cache_identity`,
+  capture/privacy policy, and hosted tools;
+- verification plan and whether execution was actually run.
+
+Use `references/report-template.md` when a full report is needed.
+
+## Anti-patterns
+
+Avoid these:
+
+- Using any checkpoint strategy except `"interaction"`.
+- Treating `in_progress`, `failed`, `cancelled`, `incomplete`, or
+  `budget_exceeded` as successful checkpoint outputs.
+- Creating a new background interaction when the source meant to poll an
+  existing `interaction_id`.
+- Claiming Kitaru can replay hosted tools, MCP, web/code execution, or
+  Antigravity sandbox internals as granular checkpoints.
+- Hiding local function-result work inside provider-owned flow instead of
+  returning it to Kitaru flow scope.
+- Mixing `model=` and `agent=` in one request.
+- Omitting `cache_identity` when project/region/credential/client differences
+  change the meaning of the cached request.
+- Saving raw prompts/provider payloads without an explicit privacy decision.
+
+## References
+
+Load only the reference file needed for the current task:
+
+- `references/concept-map.md` — source-to-target mapping table and
+  classification guidance.
+- `references/code-patterns.md` — import-complete migration examples.
+- `references/gaps-and-flags.md` — severity definitions, upstream assumptions,
+  and must-flag patterns.
+- `references/report-template.md` — Gemini Interactions-specific migration
+  report template.
+
+Kitaru source references:
+
+- Kitaru Gemini Interactions adapter docs:
+  `kitaru/docs/content/docs/adapters/gemini-interactions.mdx`
+- Adapter exports:
+  `kitaru/src/kitaru/adapters/gemini/__init__.py`
+- Adapter example:
+  `kitaru/examples/integrations/gemini_interactions_agent/README.md`

--- a/skills/kitaru-gemini-interactions-migration/references/code-patterns.md
+++ b/skills/kitaru-gemini-interactions-migration/references/code-patterns.md
@@ -1,0 +1,308 @@
+# Gemini Interactions Migration Code Patterns
+
+These examples are intentionally import-complete. Copy the shape, then adapt
+models, agents, environments, client factories, cache identities, capture policy,
+and local tool bodies to the source project. They are static/signature-oriented
+examples, not provider-live smoke tests.
+
+## 1. Minimal `client.interactions.create(...)` model replacement
+
+Source:
+
+```python
+from google import genai
+
+client = genai.Client()
+interaction = client.interactions.create(
+    model="gemini-3.5-flash",
+    input="Write a short summary of durable AI workflows.",
+)
+print(interaction.output_text)
+```
+
+Target:
+
+```python
+import kitaru
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="gemini_summary")
+
+@kitaru.flow
+def summarize(topic: str) -> str:
+    request = GeminiInteractionRequest.start(
+        f"Write a short summary of {topic}.",
+        model="gemini-3.5-flash",
+    )
+    result = runner.run_sync(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {result.status!r}")
+    return result.output_text or ""
+
+handle = summarize.run("durable AI workflows")
+print(handle.wait())
+```
+
+Outside an explicit Kitaru flow, this is adapter API wiring. For production
+replay, place the runner call in a Kitaru flow.
+
+## 2. Async interaction runner
+
+Use this when the caller is already async.
+
+```python
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="async_gemini_summary")
+
+async def summarize_async(topic: str) -> str:
+    request = GeminiInteractionRequest.start(
+        f"Explain {topic} in three bullets.",
+        model="gemini-3.5-flash",
+    )
+    result = await runner.run(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {result.status!r}")
+    return result.output_text or ""
+```
+
+Do not keep `run_sync(...)` inside an active event loop.
+
+## 3. Client factory and `cache_identity`
+
+Use `cache_identity` when the same runner name and request can point at different
+projects, regions, credential aliases, endpoints, or client configuration.
+
+```python
+from google import genai
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+
+def build_client() -> genai.Client:
+    return genai.Client()
+
+runner = KitaruGeminiInteractionsRunner(
+    name="regional_gemini_summary",
+    client_factory=build_client,
+    cache_identity="dev-project/global",
+)
+
+
+def summarize_for_region(topic: str) -> str:
+    request = GeminiInteractionRequest.start(
+        f"Summarize {topic}.",
+        model="gemini-3.5-flash",
+    )
+    result = runner.run_sync(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {result.status!r}")
+    return result.output_text or ""
+```
+
+Report caveat: `cache_identity` must be stable and non-secret. It should describe
+the client world, not contain API keys or live object representations.
+
+## 4. Resume with `previous_interaction_id`
+
+Source shape:
+
+```python
+follow_up = client.interactions.create(
+    model="gemini-3.5-flash",
+    input="Turn that into a checklist.",
+    previous_interaction_id=interaction.id,
+)
+```
+
+Target shape:
+
+```python
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="gemini_followups")
+
+
+def continue_interaction(previous_interaction_id: str) -> str:
+    request = GeminiInteractionRequest.resume(
+        "Turn that into a checklist.",
+        previous_interaction_id=previous_interaction_id,
+        model="gemini-3.5-flash",
+    )
+    result = runner.run_sync(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {result.status!r}")
+    return result.output_text or ""
+```
+
+Report caveat: server-side history remains Google-owned. Confirm the source uses
+`store=True` and that the previous interaction is still retained.
+
+## 5. `requires_action` and function-result handoff
+
+When Gemini asks for a local function result, bring that work back into the
+Kitaru flow. Do not hide it inside a provider-owned loop.
+
+```python
+import kitaru
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    GeminiInteractionResult,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="tool_call_gemini")
+
+
+def run_local_lookup(city: str) -> dict[str, str]:
+    return {"city": city, "forecast": "sunny"}
+
+
+@kitaru.flow
+def continue_after_requires_action(first: GeminiInteractionResult, city: str) -> str:
+    if first.status != "requires_action":
+        raise RuntimeError(f"Expected requires_action, got {first.status!r}")
+    if first.interaction_id is None:
+        raise RuntimeError("requires_action result did not include interaction_id")
+
+    call = next((step for step in first.steps if step.call_id), None)
+    if call is None or call.call_id is None:
+        raise RuntimeError("requires_action result did not include a function call")
+
+    local_result = run_local_lookup(city)
+    second_request = GeminiInteractionRequest.function_result(
+        previous_interaction_id=first.interaction_id,
+        function_call_id=call.call_id,
+        function_name=call.tool_name,
+        function_result=local_result,
+        model="gemini-3.5-flash",
+    )
+    second = runner.run_sync(second_request)
+    if second.status != "completed":
+        raise RuntimeError(f"Expected completed interaction, got {second.status!r}")
+    return second.output_text or ""
+```
+
+The first `requires_action` response may come from source code that already
+configured Gemini tools. Keep that provider-specific tool declaration from the
+source project; this example focuses on the Kitaru handoff after Gemini has
+already asked for a function result.
+
+If a human must approve the local work, call `kitaru.wait()` from flow scope
+between the `requires_action` result and the later `function_result` request.
+
+## 6. Poll an existing background interaction
+
+Source shape:
+
+```python
+interaction = client.interactions.create(
+    model="gemini-3.5-flash",
+    input="Run a long analysis.",
+    background=True,
+    store=True,
+)
+latest = client.interactions.get(interaction_id=interaction.id)
+```
+
+Target shape:
+
+```python
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(name="background_gemini")
+
+
+def start_background_job(topic: str):
+    request = GeminiInteractionRequest.start(
+        f"Run a long analysis of {topic}.",
+        model="gemini-3.5-flash",
+        background=True,
+        store=True,
+    )
+    return runner.run_sync(request)
+
+
+def poll_background_job(interaction_id: str):
+    return runner.run_sync(GeminiInteractionRequest.poll(interaction_id=interaction_id))
+```
+
+Report caveat: if the job is not yet `completed` or `requires_action`, Kitaru
+raises instead of saving an unfinished response as successful work. Poll the same
+`interaction_id`; do not start a duplicate background job unless that is
+intentional.
+
+## 7. Antigravity managed-agent preset
+
+Use Antigravity intentionally as a managed-agent use case, not as the adapter's
+primary identity.
+
+```python
+import kitaru
+from kitaru.adapters.gemini import (
+    GeminiInteractionRequest,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(
+    name="antigravity_repo_review",
+    cache_identity="dev-project/global",
+)
+
+@kitaru.flow
+def review_repo() -> str:
+    request = GeminiInteractionRequest.antigravity(
+        "Inspect this repository and summarize the test strategy. Do not edit files.",
+        environment="remote",
+        timeout_s=300,
+    )
+    result = runner.run_sync(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed Antigravity run, got {result.status!r}")
+    return result.output_text or ""
+```
+
+Report caveat: Antigravity sandbox files, web/code execution, managed-agent
+planning, and environment reuse remain Google-owned. The Kitaru checkpoint is the
+stable interaction response, not a filesystem snapshot.
+
+## 8. Capture policy review
+
+```python
+from kitaru.adapters.gemini import (
+    GeminiInteractionCapturePolicy,
+    KitaruGeminiInteractionsRunner,
+)
+
+runner = KitaruGeminiInteractionsRunner(
+    name="privacy_reviewed_gemini",
+    capture=GeminiInteractionCapturePolicy(
+        emit_events=True,
+        save_input=False,
+        save_request_manifest=True,
+        save_raw_interaction=False,
+        save_steps=False,
+        save_output=True,
+        save_usage=True,
+        redact_request_manifest=True,
+    ),
+)
+```
+
+Raw prompts, tool arguments, provider payloads, step contents, generated files,
+and user data may be sensitive. The migration report should say exactly what is
+saved and why.

--- a/skills/kitaru-gemini-interactions-migration/references/concept-map.md
+++ b/skills/kitaru-gemini-interactions-migration/references/concept-map.md
@@ -1,0 +1,75 @@
+# Gemini Interactions to Kitaru Concept Map
+
+Use this map while classifying source code. The safe migration story is simple:
+Google owns the hosted interaction runtime; Kitaru records one stable interaction
+response that the adapter can honestly see.
+
+## Mapping labels
+
+- `direct`: Kitaru has a close adapter surface for the same outer behavior.
+- `approximate`: Migration is possible, but replay, polling, hosted-tool,
+  environment, capture, or credential behavior differs.
+- `absent`: No safe automatic migration. The code needs redesign or explicit
+  human review before migration.
+
+## Core concepts
+
+| Gemini Interactions source pattern | Kitaru target pattern | Mapping | Notes |
+|---|---|---:|---|
+| `genai.Client(...)` | `KitaruGeminiInteractionsRunner(client=...)` or `client_factory=...` | `direct` for client injection | Use `client_factory` when credentials/project/region are created per run. |
+| `client.interactions.create(input=..., model=...)` | `runner.run/run_sync(GeminiInteractionRequest.start(input, model=...))` | `direct` | One stable model interaction response becomes one Kitaru checkpoint. |
+| `client.interactions.create(input=..., agent=...)` | `GeminiInteractionRequest.start(input, agent=..., environment=...)` | `direct` for outer call | Agent internals remain Google-owned. |
+| `client.interactions.get(interaction_id)` | `GeminiInteractionRequest.poll(interaction_id=...)` | `direct` | Polls an existing interaction; does not create duplicate provider work. |
+| `previous_interaction_id=...` | `GeminiInteractionRequest.resume(input, previous_interaction_id=...)` | `direct` | Server-side history remains Google-owned and retained only while stored. |
+| Function-result turn | `GeminiInteractionRequest.function_result(...)` | `direct` | Send a matching result after a prior `requires_action` response. |
+| `status == "completed"` | `GeminiInteractionResult(status="completed")` | `direct` | Stable final response. |
+| `status == "requires_action"` | `GeminiInteractionResult(status="requires_action")` | `approximate` | Stable handoff point, not a final answer. Return local work to Kitaru flow scope. |
+| Background interaction creation | `GeminiInteractionRequest.start(..., background=True, store=True)` | `approximate` | The provider job is Google-owned. Poll by ID until stable. |
+| In-progress/background status | Keep polling with `GeminiInteractionRequest.poll(...)` | `absent as final output` | Do not treat unfinished provider work as a successful checkpoint. |
+| `store=True` | Preserve `store=True` | `direct` | Needed for server-side history and background interactions. |
+| `store=False` | Preserve only when no resume/background behavior is needed | `approximate` | Stateless behavior changes later resume/poll expectations. |
+| `model=...` | `model=...` | `direct` | Exactly one of `model` or `agent` must be set. |
+| `agent=...` | `agent=...` | `direct` | Exactly one of `model` or `agent` must be set. |
+| Both `model=` and `agent=` | Redesign to one target | `absent until fixed` | Kitaru request validation rejects mixed targets. |
+| Model `generation_config` | `generation_config=...` on model requests | `direct` | Only valid for model interactions. |
+| Agent `agent_config` | `agent_config=...` on agent requests | `direct` | Only valid for agent interactions. |
+| Hosted tools / web / code execution / hosted MCP | Keep Google-owned; capture summaries only if policy allows | `approximate` | These are not granular Kitaru checkpoints. |
+| Local function execution after `requires_action` | Kitaru-owned flow step, then `function_result(...)` | `approximate` | This is the safe place for local tool work or `kitaru.wait()`. |
+| Antigravity agent ID | `GeminiInteractionRequest.antigravity(...)` | `direct` for preset | Uses the adapter's Antigravity preset; internals remain Google-owned. |
+| Antigravity `environment="remote"` | Same preset/default environment | `approximate` | Google provisions or reuses a sandbox. Kitaru does not snapshot files. |
+| Antigravity `background=True` | Do not use; bound with `timeout_s` | `absent` | Adapter rejects background mode for Antigravity. |
+| Raw `interaction.steps` inspection | `GeminiInteractionResult.steps` summaries | `approximate` | Summaries are metadata-first, not full hosted-step replay. |
+| `interaction.output_text` | `GeminiInteractionResult.output_text` | `direct` | Convenience final text when present. |
+| Raw provider payload capture | `GeminiInteractionCapturePolicy(save_raw_interaction=True)` | `approximate` | Privacy-sensitive; opt in only after review. |
+| Different projects/regions/credentials/client config | `KitaruGeminiInteractionsRunner(cache_identity="...")` | `direct` for cache separation | Stable, non-secret cache identity prevents cross-client cache reuse. |
+| Runner inside existing Kitaru checkpoint | Move the runner call to flow scope | `absent` | Do not auto-migrate this shape. Replaying the outer checkpoint can call Google again and duplicate cost or hosted work. |
+| `runtime="isolated"` checkpoint config | Use inline/default runtime | `absent` | Current adapter rejects isolated runtime because closures may capture live clients. |
+| Non-serializable request payloads | Materialized strings/dicts/lists | `absent until redesigned` | Do not pass clients, streams, file handles, or checkpoint output handles. |
+| Secrets in metadata/raw payloads | Use environment/secret manager | `absent until fixed` | Kitaru metadata/artifacts may be durable. |
+
+## Boundary decision guide
+
+Use `interaction` when:
+
+- one stable Gemini Interactions response should be durable as a whole;
+- the source already uses `client.interactions.create(...)` or `.get(...)`;
+- hosted tool/agent work can remain Google-owned;
+- the result envelope, step summaries, IDs, output text, and optional artifacts
+  are enough.
+
+Do not use this adapter when:
+
+- the user needs Kitaru to replay each hosted tool, MCP, web, code execution, or
+  Antigravity sandbox step;
+- unfinished provider jobs are being treated as successful application work;
+- replaying the whole interaction would duplicate an unsafe provider job;
+- project/region/credential differences cannot be represented with a stable
+  non-secret `cache_identity`.
+
+## What Kitaru does not own
+
+Kitaru does not own Google's hosted model loop, hosted tools, hosted MCP, web or
+code execution, Antigravity sandbox files, environment reuse, server-side
+interaction history, or background-job internals. If the source depends on those
+internals being replayed as separate Kitaru units, mark the mapping
+`approximate` or `absent` and explain the boundary clearly.

--- a/skills/kitaru-gemini-interactions-migration/references/gaps-and-flags.md
+++ b/skills/kitaru-gemini-interactions-migration/references/gaps-and-flags.md
@@ -1,0 +1,203 @@
+# Gemini Interactions Migration Gaps and Flags
+
+Use this file when deciding whether a migration is safe to apply automatically.
+The rule is: if replay, polling, provider state, environment, hosted tools,
+side effects, secrets, or privacy may change, make that visible in comments and
+in the migration report.
+
+## Upstream docs checked
+
+Checked on 2026-06-04 against current official docs:
+
+- Gemini Interactions guide: https://ai.google.dev/gemini-api/docs/interactions
+- Gemini Interactions API reference: https://ai.google.dev/api/interactions-api
+- Antigravity Agent: https://ai.google.dev/gemini-api/docs/antigravity-agent
+- Managed-agent environments: https://ai.google.dev/gemini-api/docs/agent-environment
+
+Assumptions recorded here: the Interactions API is still Beta/preview-shaped;
+`client.interactions.create(...)` creates an interaction resource;
+`client.interactions.get(...)` retrieves an existing interaction;
+`previous_interaction_id` uses server-side history; `store=true` is default and
+needed for background/resume workflows; background interactions must be polled by
+ID; Antigravity uses the `antigravity-preview-05-2026` agent, runs in a
+Google-hosted environment, and does not support `background=True`.
+
+## Kitaru adapter source checked
+
+Checked against local Kitaru source/docs on 2026-06-04:
+
+- `kitaru/src/kitaru/adapters/gemini/__init__.py`
+- `kitaru/src/kitaru/adapters/gemini/_agent.py`
+- `kitaru/src/kitaru/adapters/gemini/_types.py`
+- `kitaru/src/kitaru/adapters/gemini/_policy.py`
+- `kitaru/src/kitaru/adapters/gemini/_utils.py`
+- `kitaru/docs/content/docs/adapters/gemini-interactions.mdx`
+
+Kitaru assumptions: the only public checkpoint strategy is `interaction`; stable
+statuses are `completed` and `requires_action`; `GeminiInteractionRequest.poll`
+fetches an existing interaction; `GeminiInteractionRequest.antigravity(...)`
+rejects `background=True`; runner calls inside existing checkpoints are blockers
+and must be moved to flow scope; `GeminiInteractionCapturePolicy` defaults to not
+saving raw input, raw interaction payloads, or step details.
+
+## Severity levels
+
+| Severity | Meaning | Required action |
+|---|---|---|
+| `LOW` | Cosmetic or documentation-only difference. | Migrate and mention in report. |
+| `MEDIUM` | Behavior probably preserved, but settings, capture, or observability differ. | Migrate with caveat and verification step. |
+| `HIGH` | Replay, polling, provider state, hosted-tool, side-effect, privacy, or runtime behavior may change. | Require human review before applying or mark partial migration. |
+| `BLOCKER` | Migration would be unsafe or impossible without source redesign. | Do not auto-migrate; generate redesign note and report entry. |
+
+## Must-flag patterns
+
+### Unsupported granular checkpoint strategies
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** `checkpoint_strategy="calls"`, `"runner_call"`, `"granular"`,
+  `"model_call"`, `"tool_call"`, `"client_tools"`,
+  `"antigravity_steps"`, `"managed_agent_steps"`, `"step"`, or `"run"`.
+- **Why it matters:** Kitaru records one stable Gemini interaction response. It
+  does not checkpoint Google-internal model, hosted-tool, web, code, MCP,
+  Antigravity, sandbox, or managed-agent steps.
+- **Action:** use `checkpoint_strategy="interaction"` or redesign.
+
+### Unfinished background work treated as completed
+
+- **Severity:** `HIGH`.
+- **Pattern:** code treats `in_progress`, queued, running, incomplete, failed,
+  cancelled, or otherwise non-stable statuses as successful outputs.
+- **Why it matters:** replay would treat unfinished provider work as done.
+- **Action:** only accept `completed` and `requires_action` as stable Kitaru
+  boundaries. Poll the same `interaction_id` until stable or terminal.
+
+### Duplicate background jobs while polling
+
+- **Severity:** `HIGH`; `BLOCKER` for expensive or customer-visible jobs.
+- **Pattern:** migration calls `GeminiInteractionRequest.start(...,
+  background=True)` again when the source meant to poll an existing job.
+- **Why it matters:** a new create call starts new provider work and can multiply
+  cost or side effects.
+- **Action:** use `GeminiInteractionRequest.poll(interaction_id=...)` for an
+  existing background interaction.
+
+### `requires_action` hidden inside provider-owned flow
+
+- **Severity:** `HIGH`.
+- **Pattern:** local tool execution, approval, filesystem writes, or API calls
+  happen inside an opaque provider loop instead of after a stable
+  `requires_action` response.
+- **Why it matters:** Kitaru cannot checkpoint local work it never owns.
+- **Action:** return to Kitaru flow scope, run local code or `kitaru.wait()`, then
+  send `GeminiInteractionRequest.function_result(...)`.
+
+### Missing `interaction_id` or unstable previous interaction
+
+- **Severity:** `HIGH` for resume/poll workflows.
+- **Pattern:** code resumes or polls without preserving a materialized
+  `interaction_id` / `previous_interaction_id`.
+- **Why it matters:** Google uses the ID to find server-side history or the
+  background job. Without it, the app may start a new interaction.
+- **Action:** store stable IDs outside transient local variables when later turns
+  depend on them.
+
+### `store=False` used with resume or background expectations
+
+- **Severity:** `HIGH`.
+- **Pattern:** `store=False` while the source expects `previous_interaction_id`,
+  background polling, or server-side history.
+- **Why it matters:** stateless interactions do not provide the same stored
+  server-side resource behavior.
+- **Action:** use `store=True` for resume/background workflows or redesign as a
+  stateless full-history request.
+
+### Missing `cache_identity` across projects/regions/credentials
+
+- **Severity:** `HIGH`.
+- **Pattern:** the same runner name and request can run under different Google
+  projects, regions, credentials, endpoints, clients, or environments with no
+  stable `cache_identity`.
+- **Why it matters:** Kitaru's cache key cannot inspect live client internals.
+  Replay could reuse a dev result in a prod-shaped run, or cross credential
+  boundaries accidentally.
+- **Action:** add a stable, non-secret `cache_identity`, for example
+  `"project/region"` or `"credential-alias/global"`.
+
+### Antigravity internals assumed Kitaru-durable
+
+- **Severity:** `HIGH`.
+- **Pattern:** migration claims Kitaru snapshots Antigravity sandbox files,
+  web/code execution, environment reuse, managed-agent planning, or filesystem
+  operations.
+- **Why it matters:** Google owns those internals. Kitaru records the returned
+  stable interaction response and summaries only.
+- **Action:** persist important file IDs, exported artifacts, or application
+  decisions explicitly outside the hosted sandbox.
+
+### Antigravity background mode
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** `GeminiInteractionRequest.antigravity(..., background=True)` or a
+  plan to make Antigravity use background polling.
+- **Why it matters:** Kitaru's Antigravity preset rejects `background=True`, and
+  current Google docs say the Antigravity agent does not support background mode.
+- **Action:** use foreground Antigravity with `timeout_s`, or avoid the preset.
+
+### Model/agent target mix-up
+
+- **Severity:** `BLOCKER` until fixed.
+- **Pattern:** request sets both `model=` and `agent=`, neither target, or puts
+  `generation_config` on agent requests / `agent_config` on model requests.
+- **Why it matters:** Kitaru validates exactly one target and target-specific
+  config fields.
+- **Action:** split into separate model or agent requests and use the matching
+  config field.
+
+### Raw provider payload capture without privacy review
+
+- **Severity:** `MEDIUM`, or `HIGH` for customer data, source code, secrets,
+  incident data, regulated data, or sensitive tool arguments.
+- **Pattern:** migration enables `save_input=True`, `save_raw_interaction=True`,
+  or `save_steps=True` by default.
+- **Why it matters:** raw prompts, provider payloads, tool arguments, generated
+  files, step contents, and user data may be durable artifacts.
+- **Action:** choose an explicit `GeminiInteractionCapturePolicy(...)` and record
+  what is saved.
+
+### Runner call inside existing Kitaru checkpoint
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** `KitaruGeminiInteractionsRunner.run/run_sync(...)` called from a
+  `@kitaru.checkpoint` body.
+- **Why it matters:** replaying the outer checkpoint may call Google again and
+  duplicate hosted work, sandbox mutations, or API cost.
+- **Action:** do not auto-migrate this shape. Move the runner call to flow
+  scope and report it as a required manual restructuring step.
+
+### Secrets in prompts, metadata, manifests, or raw payloads
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** API keys/tokens are passed as prompts, request metadata,
+  `cache_identity`, logs, manifests, or raw payload artifacts.
+- **Why it matters:** Kitaru may store request metadata and artifacts durably.
+- **Action:** use environment variables or a secret manager; remove secrets from
+  prompts, metadata, cache identities, manifests, and logs.
+
+## Required report entry shape
+
+```markdown
+- Severity: HIGH
+- Source location: path/to/gemini_agent.py:123
+- Pattern: background job was recreated instead of polled
+- Migration action: changed to `GeminiInteractionRequest.poll(interaction_id=...)`
+- Why it matters: creating a second interaction duplicates Google-hosted work and cost
+- Required human decision: confirm where the original `interaction_id` is stored
+```
+
+## Code comment shape
+
+```python
+# TODO(migration): This path can run under different Google projects/regions but
+# has no cache_identity. Add a stable non-secret identity before relying on
+# Kitaru replay, or cached dev results could be reused in a prod-shaped run.
+```

--- a/skills/kitaru-gemini-interactions-migration/references/report-template.md
+++ b/skills/kitaru-gemini-interactions-migration/references/report-template.md
@@ -1,0 +1,197 @@
+# Migration Report: Gemini Interactions to Kitaru Adapter
+
+Use this template for `MIGRATION_REPORT.md` or for a report section in the final
+answer when the user does not want a file written.
+
+## Summary
+
+- Source framework/API: Gemini Interactions / Google GenAI / Antigravity managed agents
+- Target adapter: `kitaru.adapters.gemini.KitaruGeminiInteractionsRunner`
+- Source files reviewed:
+  - `[path]`
+- Files changed or proposed:
+  - `[path]`
+- Migration status: `[complete / partial / plan only / blocked]`
+- Classification totals:
+  - Direct: `[n]`
+  - Approximate: `[n]`
+  - Absent: `[n]`
+  - Flagged: `[n]`
+  - Blocked: `[n]`
+
+## Source Pattern Inventory
+
+| Source location | Pattern found | Classification | Severity | Notes |
+|---|---|---|---|---|
+| `[file:line]` | `client.interactions.create(...)` | `direct` | `LOW` | Replaced with `KitaruGeminiInteractionsRunner` interaction boundary. |
+| `[file:line]` | `[pattern]` | `[direct / approximate / absent]` | `[LOW / MEDIUM / HIGH / BLOCKER]` | `[concrete note]` |
+
+## Chosen Kitaru Boundaries
+
+Describe the save points in plain language.
+
+Example:
+
+- Gemini Interactions remains the hosted runtime.
+- `KitaruGeminiInteractionsRunner` is constructed once with a stable name.
+- The adapter uses `checkpoint_strategy="interaction"`, so one stable
+  `client.interactions.create(...)` or `.get(...)` response becomes one Kitaru
+  checkpoint.
+- Stable statuses are `completed` and `requires_action`.
+- Google-hosted tools, MCP, web/code execution, Antigravity sandbox state,
+  server-side history, and background job internals remain Google-owned.
+
+## Direct Translations
+
+| Source | Target | Why direct |
+|---|---|---|
+| `client.interactions.create(input=prompt, model=model)` | `runner.run_sync(GeminiInteractionRequest.start(prompt, model=model))` | Same one-turn interaction; Kitaru changes the outer doorway. |
+| `client.interactions.get(interaction_id=...)` | `runner.run_sync(GeminiInteractionRequest.poll(interaction_id=...))` | Same existing interaction ID; no duplicate provider job. |
+| `[source]` | `[target]` | `[reason]` |
+
+## Approximate Translations
+
+| Source | Target | Behavior difference | Verification step |
+|---|---|---|---|
+| Hosted tools / Antigravity work | Same request through Kitaru adapter | Google-owned internal steps are not separate Kitaru checkpoints. | Inspect result IDs/summaries and confirm important state is persisted outside hosted sandbox. |
+| `previous_interaction_id` resume | `GeminiInteractionRequest.resume(...)` | Server-side history remains Google-owned and retention-bound. | Resume a known stored interaction in the target environment. |
+| `[source]` | `[target]` | `[difference]` | `[step]` |
+
+## Flagged for Human Review
+
+| Severity | Source location | Issue | What could break | Required action |
+|---|---|---|---|---|
+| `HIGH` | `[file:line]` | `[issue]` | `[duplicate provider job / lost server-side history / unsafe raw capture / etc.]` | `[review or redesign step]` |
+
+## Adapter-Specific Notes
+
+### Runner identity and strategy
+
+- Runner name: `[name]`
+- Chosen strategy: `interaction`
+- Unsupported strategies found: `[none/list]`
+- Runner call inside an existing checkpoint: `[none / blocked and moved to flow scope]`
+
+### Target and client configuration
+
+- Uses `model=`: `[yes/no/list]`
+- Uses `agent=`: `[yes/no/list]`
+- Uses Antigravity preset: `[yes/no]`
+- Client construction: `[default / client= / client_factory=]`
+- Project/region/credential/source of truth: `[known/unknown]`
+- `cache_identity`: `[configured / missing / not needed]`
+- Risk note:
+  - `[what would happen if cache_identity is wrong or missing]`
+
+### Stable statuses and polling
+
+- Stable statuses handled: `[completed / requires_action / both]`
+- Background jobs found: `[yes/no/list]`
+- Polling uses existing `interaction_id`: `[yes/no/not applicable]`
+- Non-stable status behavior:
+  - `[poll again / blocked / needs redesign]`
+
+### `requires_action` and function results
+
+- Uses `requires_action`: `[yes/no]`
+- Function call ID source: `[where found]`
+- Local function/human work happens at flow scope: `[yes/no/needs redesign]`
+- `GeminiInteractionRequest.function_result(...)` used: `[yes/no/not applicable]`
+- Replay consequence:
+  - `[what local work can be replayed or skipped]`
+
+### Server-side state and retention
+
+- Uses `previous_interaction_id`: `[yes/no]`
+- Uses `store`: `[true/false/default/unknown]`
+- Stored interaction ID persistence: `[where/how]`
+- Retention caveat:
+  - `[server-side history remains Google-owned and retention-bound]`
+
+### Antigravity and environments
+
+- Agent ID/preset: `[antigravity-preview-05-2026 / custom / not applicable]`
+- Environment: `[remote / env id / config / not applicable]`
+- Background mode requested: `[no / yes BLOCKER]`
+- Hosted files/sandbox note:
+  - `[what remains Google-owned]`
+
+### Hosted tools and steps
+
+- Hosted tools found: `[web / code_execution / MCP / Google Search / URL context / list]`
+- Step summaries captured: `[yes/no/default]`
+- Raw step/provider payload capture: `[yes/no]`
+- Granular replay note:
+  - `[hosted tool and step internals are not Kitaru checkpoints]`
+
+### Capture and privacy policy
+
+- Capture policy configured: `[yes/no]`
+- Input saved: `[yes/no/default]`
+- Request manifest saved: `[yes/no/default]`
+- Raw interaction saved: `[yes/no/default]`
+- Steps saved: `[yes/no/default]`
+- Output saved: `[yes/no/default]`
+- Usage saved: `[yes/no/default]`
+- Sensitive data risk: `[none known / needs review]`
+
+## Behavioral Differences
+
+Explain concrete differences introduced by the migration.
+
+Examples:
+
+- "The source previously called `client.interactions.create(...)` directly. The
+  migrated code calls the same hosted API through `KitaruGeminiInteractionsRunner`,
+  so Kitaru can record one stable interaction response."
+- "A `requires_action` response is saved as a durable handoff point. Local tool
+  work happens in the Kitaru flow, then the flow sends a later function-result
+  interaction."
+- "Antigravity filesystem and sandbox state remain Google-owned. Kitaru does not
+  snapshot the remote environment."
+- "Polling uses `GeminiInteractionRequest.poll(interaction_id=...)`, so replay
+  does not accidentally start a second background job."
+
+## What Is Not Migrated
+
+| Item | Reason | Recommended redesign |
+|---|---|---|
+| `[item]` | `[why absent or unsafe]` | `[redesign]` |
+
+## Verification Plan
+
+- Static checks:
+  - `[imports resolve / strategy is interaction / exactly one of model or agent / cache_identity reviewed]`
+- Local dry-run:
+  - `[not applicable / signature-only check]`
+- Provider-backed run:
+  - `[command or not run because API key/Vertex access unavailable]`
+- Kitaru behavior checks:
+  - Confirm execution appears in dashboard or `kitaru executions list`.
+  - Confirm one interaction checkpoint appears for stable responses.
+  - Confirm `requires_action` returns work to flow scope.
+  - Confirm polling uses the same `interaction_id` instead of creating a new job.
+  - Confirm replay does not duplicate unsafe provider work or local side effects.
+
+## Docs and Reference Links
+
+- Kitaru Gemini Interactions adapter docs:
+  `kitaru/docs/content/docs/adapters/gemini-interactions.mdx`
+- Kitaru Gemini adapter exports:
+  `kitaru/src/kitaru/adapters/gemini/__init__.py`
+- Skill references:
+  - `skills/kitaru-gemini-interactions-migration/references/concept-map.md`
+  - `skills/kitaru-gemini-interactions-migration/references/code-patterns.md`
+  - `skills/kitaru-gemini-interactions-migration/references/gaps-and-flags.md`
+- Official docs checked:
+  - https://ai.google.dev/gemini-api/docs/interactions
+  - https://ai.google.dev/api/interactions-api
+  - https://ai.google.dev/gemini-api/docs/antigravity-agent
+
+## Recommended Next Steps
+
+1. `[Run provider-backed model or Antigravity smoke test if credentials are available]`
+2. `[Review HIGH/BLOCKER polling, cache_identity, Antigravity, and privacy items]`
+3. `[Decide whether client construction should use client= or client_factory=]`
+4. `[Add project-specific tests for replay, requires_action, and duplicate-job prevention]`
+5. `[Update user-facing docs or examples if this migration changes public behavior]`

--- a/skills/kitaru-langgraph-migration/SKILL.md
+++ b/skills/kitaru-langgraph-migration/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: kitaru-langgraph-migration
+description: >
+  Migrate existing LangGraph and LangChain agent code to Kitaru's LangGraph
+  adapter. Use when code mentions LangGraph, StateGraph, CompiledStateGraph,
+  graph.invoke, graph.ainvoke, stream, astream, interrupt, Command, thread_id,
+  checkpointer, InMemorySaver, MemorySaver, create_agent,
+  KitaruGraphRunner, LangGraphRunRequest, LangGraphRunResult,
+  KitaruLangGraphMiddleware, build_resume_request, wait_for_interrupt,
+  checkpoint_strategy, graph_call, calls, callbacks, event streams, Deep Agents,
+  or checkpointers. Helps classify direct, approximate, and absent mappings,
+  choose graph_call vs middleware-backed calls boundaries, preserve LangGraph
+  ownership of graph state, and produce a migration report.
+---
+
+# Migrate LangGraph to Kitaru
+
+## What this skill does
+
+Use this skill to inspect LangGraph, LangChain `create_agent(...)`, or Deep
+Agents code and move only the supportable durability boundary to Kitaru's
+`kitaru.adapters.langgraph` surfaces.
+
+The output should be conservative:
+
+1. A source pattern inventory.
+2. A migration plan that classifies each important pattern as `direct`,
+   `approximate`, or `absent`.
+3. Migrated or proposed code using `KitaruGraphRunner`, `LangGraphRunRequest`,
+   `LangGraphRunResult`, and, when safe, `KitaruLangGraphMiddleware`.
+4. A `MIGRATION_REPORT.md` section or file that names replay, interrupt,
+   checkpointer, state, stream, and side-effect risks.
+
+Do not promise that Kitaru replaces LangGraph persistence or checkpoints every
+node inside the graph.
+
+## Mental model: LangGraph owns the graph; Kitaru records the doorway
+
+LangGraph still owns graph state, checkpointers, stores, interrupts,
+`thread_id`, graph-local replay, and any Deep Agents sandbox or filesystem
+backend.
+
+Kitaru can record either:
+
+- one outer graph invocation with `checkpoint_strategy="graph_call"`; or
+- synchronous LangChain model/tool calls that physically pass through
+  `KitaruLangGraphMiddleware` while a `KitaruGraphRunner` is active with
+  `checkpoint_strategy="calls"`.
+
+A useful picture: LangGraph is the house. Kitaru can put a camera at the front
+door and, if LangChain middleware is installed, at a few visible interior
+doorways. It cannot see through walls into checkpointers, stores, hosted tools,
+or async model/tool internals that do not pass through a true Kitaru checkpoint.
+
+## When to use this skill
+
+Use it when the user asks to:
+
+- replace raw `graph.invoke(...)` / `graph.ainvoke(...)` entrypoints with
+  `KitaruGraphRunner.invoke(...)` / `ainvoke(...)`;
+- add Kitaru around a `StateGraph` / `CompiledStateGraph`;
+- choose between `checkpoint_strategy="graph_call"` and `"calls"`;
+- migrate LangGraph interrupts and `Command(resume=...)` handling;
+- review LangGraph checkpointers, stores, `thread_id`, `InMemorySaver`, or
+  `MemorySaver` assumptions;
+- add `KitaruLangGraphMiddleware` to a LangChain `create_agent(...)` agent;
+- reason about callbacks, events, `stream`, `astream`, `stream_events`, or Deep
+  Agents under Kitaru;
+- produce a migration report for LangGraph code.
+
+## When not to use this skill
+
+Do not use it to:
+
+- replace LangGraph's checkpointer or store with Kitaru;
+- promise Kitaru can replay every LangGraph node, edge, interrupt, event, or
+  Deep Agents filesystem operation;
+- migrate PydanticAI, OpenAI Agents SDK, Claude Agent SDK, Gemini Interactions,
+  or raw provider SDK code;
+- put Kitaru waits inside graph nodes or checkpoints without a flow-scope
+  redesign;
+- invent unsupported Kitaru strategies beyond `graph_call` and `calls`.
+
+## The three mapping types
+
+Classify each source pattern before editing:
+
+- `direct`: Kitaru has a clear adapter surface for the same outer behavior.
+  Example: `graph.invoke(input, config)` becomes
+  `runner.invoke(LangGraphRunRequest.start(input, thread_id=...))`.
+- `approximate`: The migration is possible, but replay, observability,
+  interrupt, streaming, state, or persistence behavior differs. Example:
+  callbacks remain observability, not replay boundaries.
+- `absent`: There is no safe automatic migration until the source is redesigned.
+  Example: a claim that Kitaru will replace a production LangGraph checkpointer.
+
+Unsupported patterns must not be silently approximated. Add a concrete
+`# TODO(migration): ...` comment near proposed code, list it in the report, and
+explain the redesign needed.
+
+## Migration workflow
+
+1. **Inspect source first.** Find graph construction, compile-time checkpointers
+   and stores, `thread_id` handling, raw invoke/ainvoke/stream calls, interrupts,
+   `Command(resume=...)`, callbacks, middleware, Deep Agents usage, and existing
+   Kitaru flows/checkpoints.
+2. **Classify every pattern.** Use `references/concept-map.md` and
+   `references/gaps-and-flags.md`. Count direct, approximate, flagged, and
+   blocked items.
+3. **Choose Kitaru boundaries.** Prefer `checkpoint_strategy="graph_call"` unless
+   the source clearly uses synchronous LangChain model/tool handlers that can be
+   wrapped by `KitaruLangGraphMiddleware`.
+4. **Present the plan before generating code** when the migration is more than a
+   tiny entrypoint replacement. Name high-risk seams before editing.
+5. **Draft migrated code.** Keep the source graph. Add `KitaruGraphRunner` and
+   serializable `LangGraphRunRequest` objects. Add explicit result status
+   handling for `completed` vs `interrupted`.
+6. **Produce `MIGRATION_REPORT.md`.** Include the pattern inventory,
+   classifications, chosen boundary, flags, behavior differences, and
+   verification plan.
+7. **Verify behavior.** Prefer static/import checks and a small local graph. If
+   provider keys or production checkpointers are unavailable, say so.
+
+## Pattern detection checklist
+
+Look for:
+
+- `StateGraph(...)`, `.compile(...)`, `CompiledStateGraph`, `graph.invoke(...)`,
+  `graph.ainvoke(...)`, `stream(...)`, `astream(...)`, or `stream_events(...)`.
+- `config={"configurable": {"thread_id": ...}}`, `checkpoint_id`, or
+  `checkpoint_ns`.
+- `interrupt(...)`, `Command(resume=...)`, `wait_for_interrupt(...)`, and
+  result status branches.
+- `InMemorySaver`, `MemorySaver`, Postgres/Redis/custom checkpointers, stores,
+  or memory APIs.
+- `create_agent(...)`, `middleware=[...]`, and whether
+  `KitaruLangGraphMiddleware()` is installed.
+- callbacks, LangSmith tracing, event streams, or stream handlers with external
+  side effects.
+- Deep Agents middleware/backends, filesystem tools, subagents, sandboxes, or
+  state backends.
+- Existing `@kitaru.flow` or `@kitaru.checkpoint` wrappers.
+- Non-serializable graph outputs, state snapshots, clients, file handles, or raw
+  framework objects returned from checkpoints.
+
+## Boundary decision rules
+
+- Keep LangGraph as the graph runtime.
+- Default to `KitaruGraphRunner(graph, checkpoint_strategy="graph_call")` for a
+  clean outer checkpoint around one completed or interrupted invocation.
+- Use `checkpoint_strategy="calls"` only when synchronous LangChain model/tool
+  calls pass through `KitaruLangGraphMiddleware` while the runner is active.
+- Treat async calls mode as metadata-only today; do not promise true async
+  granular checkpoints.
+- Keep LangGraph checkpointers/stores in place. Kitaru records its own boundary;
+  it does not replace LangGraph's persistence layer.
+- Preserve stable `thread_id` handling. If the source has no stable thread ID,
+  flag it before migration.
+- Treat callbacks, events, and streams as observability unless a concrete Kitaru
+  checkpoint boundary stores a final serializable value.
+- Do not put Kitaru `wait()` calls inside graph nodes or checkpoints. Bridge
+  LangGraph interrupts at flow scope when human input is needed.
+
+## LangGraph migration quick guide
+
+Minimal outer graph call:
+
+```python
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+class State(TypedDict):
+    topic: str
+    summary: str
+
+def summarize(state: State) -> dict[str, str]:
+    return {"summary": f"Summary for {state['topic']}"}
+
+builder = StateGraph(State)
+builder.add_node("summarize", summarize)
+builder.add_edge(START, "summarize")
+builder.add_edge("summarize", END)
+graph = builder.compile()
+
+runner = KitaruGraphRunner(graph, name="summary_graph")
+request = LangGraphRunRequest.start(
+    {"topic": "durable agents", "summary": ""},
+    thread_id="thread-001",
+)
+result = runner.invoke(request)
+if result.status != "completed":
+    raise RuntimeError(f"Expected completed graph, got {result.status!r}")
+print(result.output)
+```
+
+For full examples, load `references/code-patterns.md`.
+
+## Gap handling rules
+
+When a pattern is unsafe or unsupported:
+
+1. Do not silently approximate it.
+2. Add a concrete `# TODO(migration): ...` comment near proposed code.
+3. Add a report entry with severity `LOW`, `MEDIUM`, `HIGH`, or `BLOCKER`.
+4. Explain the bad outcome the flag prevents. Example: "the graph resumes from a
+   LangGraph interrupt, so code before `interrupt()` in that node may run again."
+5. Propose the smallest safe redesign.
+
+## Report requirements
+
+Every non-trivial migration must include or draft `MIGRATION_REPORT.md` with:
+
+- source files reviewed and changed/proposed;
+- classification totals;
+- source pattern inventory with `file:line` locations;
+- chosen Kitaru graph boundary and checkpoint strategy;
+- direct translations;
+- approximate translations and caveats;
+- flagged items with severity and required action;
+- LangGraph-specific notes for `thread_id`, checkpointers/stores,
+  interrupts/resume, middleware/calls mode, streams/events, Deep Agents, capture
+  policy, and side effects;
+- verification plan and whether execution was actually run.
+
+Use `references/report-template.md` when a full report is needed.
+
+## Anti-patterns
+
+Avoid these:
+
+- Replacing a LangGraph checkpointer/store with Kitaru.
+- Claiming Kitaru replays every node, edge, stream event, or Deep Agents action.
+- Using `calls` without `KitaruLangGraphMiddleware` and calling it granular
+  Kitaru checkpointing.
+- Treating async `awrap_model_call` / `awrap_tool_call` metadata as true
+  checkpoints.
+- Using `InMemorySaver` as production restart-durable storage.
+- Ignoring `result.status == "interrupted"`.
+- Returning raw graph state snapshots or non-serializable framework objects from
+  checkpoints.
+- Hiding durable side effects in stream/callback handlers without idempotency.
+
+## References
+
+Load only the reference file needed for the current task:
+
+- `references/concept-map.md` — source-to-target mapping table and
+  classification guidance.
+- `references/code-patterns.md` — import-complete migration examples.
+- `references/gaps-and-flags.md` — severity definitions, upstream assumptions,
+  and must-flag patterns.
+- `references/report-template.md` — LangGraph-specific migration report template.
+
+Kitaru source references:
+
+- Kitaru LangGraph adapter docs:
+  `kitaru/docs/content/docs/adapters/langgraph.mdx`
+- Adapter exports:
+  `kitaru/src/kitaru/adapters/langgraph/__init__.py`
+- LangChain middleware:
+  `kitaru/src/kitaru/adapters/langgraph/langchain.py`
+- Adapter example:
+  `kitaru/examples/integrations/langgraph_agent/README.md`

--- a/skills/kitaru-langgraph-migration/references/code-patterns.md
+++ b/skills/kitaru-langgraph-migration/references/code-patterns.md
@@ -1,0 +1,274 @@
+# LangGraph Migration Code Patterns
+
+These examples are intentionally import-complete. Copy the shape, then adapt
+state schemas, graph names, thread IDs, prompts, and checkpoint choices to the
+source project. They are static/signature-oriented examples, not provider-live
+smoke tests.
+
+## 1. Minimal `graph.invoke(...)` replacement
+
+Source:
+
+```python
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+class State(TypedDict):
+    topic: str
+    summary: str
+
+def summarize(state: State) -> dict[str, str]:
+    return {"summary": f"Summary for {state['topic']}"}
+
+builder = StateGraph(State)
+builder.add_node("summarize", summarize)
+builder.add_edge(START, "summarize")
+builder.add_edge("summarize", END)
+graph = builder.compile()
+
+result = graph.invoke({"topic": "durable agents", "summary": ""})
+print(result["summary"])
+```
+
+Target:
+
+```python
+from typing import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+class State(TypedDict):
+    topic: str
+    summary: str
+
+def summarize(state: State) -> dict[str, str]:
+    return {"summary": f"Summary for {state['topic']}"}
+
+builder = StateGraph(State)
+builder.add_node("summarize", summarize)
+builder.add_edge(START, "summarize")
+builder.add_edge("summarize", END)
+graph = builder.compile()
+
+runner = KitaruGraphRunner(graph, name="summary_graph")
+request = LangGraphRunRequest.start(
+    {"topic": "durable agents", "summary": ""},
+    thread_id="summary-thread-001",
+)
+result = runner.invoke(request)
+if result.status != "completed":
+    raise RuntimeError(f"Expected completed graph, got {result.status!r}")
+print(result.output)
+```
+
+Outside an explicit Kitaru flow, this is adapter API wiring. For a production
+workflow, place the runner call in a Kitaru flow.
+
+## 2. Explicit Kitaru flow with `graph_call`
+
+Use this when the workflow needs one clear durable graph result.
+
+```python
+from typing import TypedDict
+
+import kitaru
+from langgraph.graph import END, START, StateGraph
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+class State(TypedDict):
+    topic: str
+    summary: str
+
+def summarize(state: State) -> dict[str, str]:
+    return {"summary": f"Summary for {state['topic']}"}
+
+builder = StateGraph(State)
+builder.add_node("summarize", summarize)
+builder.add_edge(START, "summarize")
+builder.add_edge("summarize", END)
+graph = builder.compile()
+runner = KitaruGraphRunner(
+    graph,
+    name="summary_graph",
+    checkpoint_strategy="graph_call",
+)
+
+@kitaru.flow
+def summarize_topic(topic: str, thread_id: str) -> str:
+    request = LangGraphRunRequest.start(
+        {"topic": topic, "summary": ""},
+        thread_id=thread_id,
+    )
+    result = runner.invoke(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed graph, got {result.status!r}")
+    output = result.output
+    if not isinstance(output, dict):
+        raise TypeError("Expected dict output from summary graph")
+    return str(output["summary"])
+
+handle = summarize_topic.run("LangGraph adapters", "summary-thread-001")
+print(handle.wait())
+```
+
+## 3. Async graph invocation
+
+Use async runner methods in async application code.
+
+```python
+from typing import Any
+
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+async def run_graph_async(graph: Any, message: str, thread_id: str) -> object:
+    runner = KitaruGraphRunner(graph, name="async_agent_graph")
+    request = LangGraphRunRequest.start(
+        {"messages": [{"role": "user", "content": message}]},
+        thread_id=thread_id,
+    )
+    result = await runner.ainvoke(request)
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed graph, got {result.status!r}")
+    return result.output
+```
+
+Do not convert async callers back to sync `invoke(...)` just to make migration
+look smaller.
+
+## 4. Interrupt and resume bridge
+
+Source shape:
+
+```python
+from langgraph.types import Command
+
+first = graph.invoke(input_state, config={"configurable": {"thread_id": thread_id}})
+second = graph.invoke(Command(resume={"approved": True}), config={"configurable": {"thread_id": thread_id}})
+```
+
+Target shape:
+
+```python
+from typing import Any
+
+from kitaru.adapters.langgraph import (
+    KitaruGraphRunner,
+    LangGraphRunRequest,
+    build_resume_request,
+)
+
+
+def run_then_resume(
+    graph: Any,
+    input_state: dict[str, Any],
+    thread_id: str,
+    approval: bool,
+) -> object:
+    runner = KitaruGraphRunner(graph, name="approval_graph")
+    first = runner.invoke(LangGraphRunRequest.start(input_state, thread_id=thread_id))
+    if first.status == "completed":
+        return first.output
+    if first.status != "interrupted":
+        raise RuntimeError(f"Unexpected LangGraph status: {first.status!r}")
+
+    resume_request = build_resume_request(first, {"approved": approval})
+    second = runner.invoke(resume_request)
+    if second.status != "completed":
+        raise RuntimeError(f"Expected completed resume, got {second.status!r}")
+    return second.output
+```
+
+If the project needs a human wait, keep that wait in the surrounding Kitaru flow
+and call `wait_for_interrupt(...)` from flow scope, not from a checkpoint.
+
+## 5. LangChain `create_agent(...)` with middleware-backed `calls`
+
+Use this only when the source is a LangChain agent and the relevant calls are
+synchronous middleware-visible model/tool calls.
+
+```python
+from langchain.agents import create_agent
+from langchain.tools import tool
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+from kitaru.adapters.langgraph.langchain import KitaruLangGraphMiddleware
+
+@tool
+def lookup_order(order_id: str) -> str:
+    """Return a deterministic order summary."""
+    return f"Order {order_id} is processing."
+
+agent_graph = create_agent(
+    model="openai:gpt-5-nano",
+    tools=[lookup_order],
+    middleware=[KitaruLangGraphMiddleware()],
+)
+runner = KitaruGraphRunner(
+    agent_graph,
+    name="support_agent",
+    checkpoint_strategy="calls",
+)
+request = LangGraphRunRequest.start(
+    {"messages": [{"role": "user", "content": "Where is order ORD-1007?"}]},
+    thread_id="support-thread-001",
+)
+result = runner.invoke(request)
+if result.status != "completed":
+    raise RuntimeError(f"Expected completed agent, got {result.status!r}")
+print(result.output)
+```
+
+If `KitaruLangGraphMiddleware` is missing, `calls` mode should be reported as
+metadata-only, not as per-call checkpointing.
+
+## 6. Keep LangGraph checkpointers in place
+
+Source:
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+
+checkpointer = InMemorySaver()
+graph = builder.compile(checkpointer=checkpointer)
+config = {"configurable": {"thread_id": "conversation-1"}}
+output = graph.invoke(input_state, config=config)
+```
+
+Target:
+
+```python
+from langgraph.checkpoint.memory import InMemorySaver
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+checkpointer = InMemorySaver()
+graph = builder.compile(checkpointer=checkpointer)
+runner = KitaruGraphRunner(graph, name="conversation_graph")
+request = LangGraphRunRequest.start(input_state, thread_id="conversation-1")
+result = runner.invoke(request)
+```
+
+Report caveat: `InMemorySaver` is local/demo/test storage. For production restart
+resilience, switch to a durable LangGraph checkpointer; do not claim Kitaru makes
+LangGraph's in-memory state durable.
+
+## 7. Stream/event handling caveat
+
+```python
+from typing import Any
+
+from kitaru.adapters.langgraph import KitaruGraphRunner, LangGraphRunRequest
+
+
+def collect_final_output(graph: Any, input_state: dict[str, Any], thread_id: str) -> object:
+    runner = KitaruGraphRunner(graph, name="streaming_graph")
+    # Prefer one final invoke boundary when stream events are only UI progress.
+    result = runner.invoke(LangGraphRunRequest.start(input_state, thread_id=thread_id))
+    if result.status != "completed":
+        raise RuntimeError(f"Expected completed graph, got {result.status!r}")
+    return result.output
+```
+
+If the source stream handler writes progress to Slack or a database, flag it.
+Replay may send the same progress twice, while cached replay may skip the handler
+entirely.

--- a/skills/kitaru-langgraph-migration/references/concept-map.md
+++ b/skills/kitaru-langgraph-migration/references/concept-map.md
@@ -1,0 +1,74 @@
+# LangGraph to Kitaru Concept Map
+
+Use this map while classifying source code. The safe migration story is simple:
+LangGraph owns graph execution and graph state; Kitaru records only the boundary
+it can honestly see.
+
+## Mapping labels
+
+- `direct`: Kitaru has a close adapter surface for the same outer behavior.
+- `approximate`: Migration is possible, but replay, observability, interrupt,
+  stream, state, or persistence behavior differs.
+- `absent`: No safe automatic migration. The code needs redesign or explicit
+  human review before migration.
+
+## Core concepts
+
+| LangGraph source pattern | Kitaru target pattern | Mapping | Notes |
+|---|---|---:|---|
+| `graph.invoke(input, config=...)` | `runner.invoke(LangGraphRunRequest.start(input, thread_id=...))` | `direct` | Keep the same graph. Kitaru changes the entrypoint. |
+| `await graph.ainvoke(input, config=...)` | `await runner.ainvoke(LangGraphRunRequest.start(...))` | `direct` | Use async runner in async code. |
+| `thread_id` in `configurable` | `LangGraphRunRequest.start(..., thread_id=...)` | `direct` | Stable thread IDs remain required for LangGraph persistence/resume. |
+| `checkpoint_id` / `checkpoint_ns` | Matching request fields | `direct` | Preserve when the source intentionally targets a checkpoint namespace. |
+| `config={"configurable": {...}}` | `config=` / `configurable=` request fields | `direct` | Keep serializable values. Do not put secrets in metadata. |
+| `context=...` on graph call | `context=` or `context_factory` | `approximate` | Review serialization and tenant/user/cache identity needs. |
+| Raw `CompiledStateGraph` | Same graph passed to `KitaruGraphRunner` | `direct` | Kitaru does not rewrite graph nodes or edges. |
+| `checkpoint_strategy="graph_call"` | One Kitaru checkpoint around completed/interrupted invocation | `approximate` | Default recommendation. LangGraph still creates its own graph checkpoints if configured. |
+| `checkpoint_strategy="calls"` with `KitaruLangGraphMiddleware` | True sync model/tool call checkpoints plus event metadata | `approximate` | Only for synchronous LangChain model/tool handlers that pass through middleware. |
+| `checkpoint_strategy="calls"` without middleware | Trace metadata only, not granular Kitaru checkpoints | `approximate` or `absent` | Use only if metadata is enough. Do not claim per-call replay. |
+| Async LangChain model/tool middleware calls | Metadata-only async tracking | `approximate` | Current Kitaru calls mode does not open true async granular checkpoints. |
+| `create_agent(...)` from LangChain | Same agent/graph plus optional `KitaruLangGraphMiddleware()` | `direct` for outer call, `approximate` for calls | Middleware must be installed for granular sync call checkpoints. |
+| `interrupt(...)` | `LangGraphRunResult(status="interrupted")` | `approximate` | The paused graph is LangGraph-owned; Kitaru returns a serializable pending-state summary. |
+| `Command(resume=...)` | `build_resume_request(...)` or `LangGraphRunRequest.resume(...)` | `approximate` | Resume at flow scope and check status again after resume. |
+| `wait_for_interrupt(...)` | Kitaru flow-scope wait bridge | `approximate` | Good for human input; do not call inside checkpoints. |
+| LangGraph checkpointer | Keep graph checkpointer | `direct` for preserving source | Kitaru does not replace it. |
+| `InMemorySaver` / `MemorySaver` | Keep only for local/demo/test or replace with durable LangGraph store | `approximate` | Not restart-durable across processes or pods. |
+| LangGraph store/memory | Keep LangGraph-owned | `approximate` | Kitaru records adapter outputs/artifacts, not graph memory internals. |
+| `stream(...)`, `astream(...)`, `stream_events(...)` | Prefer final `invoke`/`ainvoke` boundary, or explicit stream collection | `approximate` | Events are observability. Stream handlers with side effects need idempotency. |
+| callbacks / LangSmith tracing | Leave as observability | `approximate` | Useful for debugging, not Kitaru replay boundaries. |
+| Deep Agents middleware/backends/filesystem | Outer graph call only, unless visible sync LangChain calls are wrapped | `approximate` or `absent` | Sandbox/filesystem/backend remain Deep Agents-owned. |
+| Side-effectful graph nodes | Application-owned idempotency or explicit Kitaru checkpoint outside graph | `approximate` or `absent` | Kitaru cannot make hidden graph-node side effects safe automatically. |
+| Non-serializable graph output/state | Return serializable value or artifact reference | `absent until redesigned` | Raw clients, state snapshots, streams, and file handles are unsafe checkpoint outputs. |
+| Missing stable graph name | Add `name=` to `KitaruGraphRunner` | `absent until fixed` | Stable names are needed for readable checkpoints/artifacts. |
+| Missing stable thread ID | Add stable `thread_id` generation/storage | `BLOCKER` for resume workflows | New thread IDs create new LangGraph threads instead of resuming. |
+
+## Boundary decision guide
+
+Choose `graph_call` when:
+
+- one durable record around the graph invocation is enough;
+- the graph may interrupt and resume through LangGraph state;
+- the project has async graph calls, streams, callbacks, Deep Agents, or opaque
+  graph internals;
+- the user wants `flow.run(...).wait()` to return one result envelope.
+
+Choose `calls` only when:
+
+- the graph is a LangChain `create_agent(...)`-style graph;
+- `KitaruLangGraphMiddleware()` is installed in the agent middleware list;
+- the source uses synchronous model/tool handlers;
+- per-model/per-tool Kitaru artifacts are worth the extra complexity.
+
+Do not choose `calls` when:
+
+- there is no Kitaru middleware;
+- the desired granular calls are async-only;
+- the call runs inside an existing Kitaru checkpoint;
+- the user expects Kitaru to replace LangGraph checkpointers.
+
+## What Kitaru does not own
+
+Kitaru does not own LangGraph's checkpointer, store, state snapshots, interrupt
+mechanics, node replay, event stream, or Deep Agents sandbox/filesystem. If the
+source depends on those internals being replayed as separate Kitaru units, mark
+the mapping `approximate` or `absent` and explain the boundary clearly.

--- a/skills/kitaru-langgraph-migration/references/gaps-and-flags.md
+++ b/skills/kitaru-langgraph-migration/references/gaps-and-flags.md
@@ -1,0 +1,154 @@
+# LangGraph Migration Gaps and Flags
+
+Use this file when deciding whether a migration is safe to apply automatically.
+The rule is: if replay, interrupt, stream, state, persistence, side effects, or
+secret handling may change, make that visible in comments and in the migration
+report.
+
+## Upstream docs checked
+
+Checked on 2026-06-04 against current official docs:
+
+- LangGraph overview: https://docs.langchain.com/oss/python/langgraph
+- LangGraph persistence: https://docs.langchain.com/oss/python/langgraph/persistence
+- LangGraph interrupts: https://docs.langchain.com/oss/python/langgraph/interrupts
+- LangGraph streaming: https://docs.langchain.com/oss/python/langgraph/streaming
+- LangChain agents: https://docs.langchain.com/oss/python/langchain/agents
+
+Assumptions recorded here: LangGraph remains the stateful graph runtime;
+checkpointers organize graph state by `thread_id`; interrupts resume through
+LangGraph state and commands; LangChain `create_agent(...)` supports middleware;
+Deep Agents/filesystem/memory middleware are LangChain/LangGraph-owned, not
+Kitaru-owned.
+
+## Severity levels
+
+| Severity | Meaning | Required action |
+|---|---|---|
+| `LOW` | Cosmetic or documentation-only difference. | Migrate and mention in report. |
+| `MEDIUM` | Behavior probably preserved, but settings or observability differ. | Migrate with caveat and verification step. |
+| `HIGH` | Replay, interrupt, stream, state, side-effect, or persistence behavior may change. | Require human review before applying or mark partial migration. |
+| `BLOCKER` | Migration would be unsafe or impossible without source redesign. | Do not auto-migrate; generate redesign note and report entry. |
+
+## Must-flag patterns
+
+### Missing or unstable `thread_id`
+
+- **Severity:** `BLOCKER` for interrupt/resume or conversation memory flows;
+  `HIGH` otherwise.
+- **Pattern:** graph calls without stable `configurable.thread_id`, random IDs
+  where resume is expected, or thread IDs derived from volatile trace IDs.
+- **Why it matters:** LangGraph uses `thread_id` as the pointer to graph state.
+  A new ID is a new thread, not a resume.
+- **Action:** add a stable application-owned thread ID before migration.
+
+### Replacing LangGraph persistence with Kitaru
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** migration removes checkpointers/stores or claims Kitaru replaces
+  LangGraph checkpoints.
+- **Why it matters:** LangGraph interrupts, memory, and graph-local replay depend
+  on LangGraph's own persistence layer.
+- **Action:** keep or improve the LangGraph checkpointer/store. Use Kitaru only
+  around adapter-visible boundaries.
+
+### `InMemorySaver` used as production durability
+
+- **Severity:** `HIGH` or `BLOCKER` for multi-process/remote deployment.
+- **Pattern:** `InMemorySaver()` / `MemorySaver()` in code expected to survive a
+  process restart or pod replacement.
+- **Why it matters:** in-memory state disappears when the process dies.
+- **Action:** keep for tests/demos only, or switch to a durable LangGraph
+  checkpointer before claiming restart durability.
+
+### `calls` mode without `KitaruLangGraphMiddleware`
+
+- **Severity:** `HIGH`.
+- **Pattern:** `KitaruGraphRunner(..., checkpoint_strategy="calls")` but no
+  Kitaru middleware in the LangChain agent.
+- **Why it matters:** Kitaru may collect run metadata, but it cannot open true
+  per-model/per-tool checkpoints if calls never pass through the middleware.
+- **Action:** install `KitaruLangGraphMiddleware()` or switch to `graph_call`.
+
+### Async calls treated as true granular checkpoints
+
+- **Severity:** `HIGH`.
+- **Pattern:** migration claims async LangChain model/tool calls are separately
+  durable Kitaru checkpoints.
+- **Why it matters:** current Kitaru async middleware tracking is metadata-only.
+- **Action:** describe async calls as metadata-only or use a coarser
+  `graph_call` boundary.
+
+### Interrupt results treated as completed
+
+- **Severity:** `HIGH`.
+- **Pattern:** code reads `result.output` without checking
+  `result.status == "completed"` when interrupts are possible.
+- **Why it matters:** an interrupted result is a paused graph pointer, not a final
+  answer.
+- **Action:** add explicit `completed` / `interrupted` status handling and resume
+  through `build_resume_request(...)` or `LangGraphRunRequest.resume(...)`.
+
+### `wait_for_interrupt(...)` inside a checkpoint
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** Kitaru human wait bridge is called from inside a user checkpoint or
+  graph-node checkpoint.
+- **Why it matters:** waits must be created at Kitaru flow scope.
+- **Action:** move the wait bridge to the surrounding `@kitaru.flow`.
+
+### Stream/callback side effects
+
+- **Severity:** `HIGH`; `BLOCKER` for destructive/customer-visible effects.
+- **Pattern:** `stream`, `astream`, `stream_events`, callbacks, or LangSmith
+  hooks write to Slack/files/databases or external APIs.
+- **Why it matters:** replay may duplicate those writes, or cached results may
+  skip them.
+- **Action:** make handlers idempotent or move important side effects after a
+  final checkpointed result.
+
+### Deep Agents sandbox/filesystem assumed durable under Kitaru
+
+- **Severity:** `HIGH`.
+- **Pattern:** migration claims Kitaru snapshots Deep Agents filesystem,
+  subagents, sandboxes, or backend state.
+- **Why it matters:** those internals remain Deep Agents/LangChain-owned.
+- **Action:** record only outer graph calls or visible sync middleware calls;
+  store important file/state references explicitly.
+
+### Non-serializable graph outputs
+
+- **Severity:** `HIGH` to `BLOCKER`.
+- **Pattern:** checkpoints return raw `StateSnapshot`, graph objects, clients,
+  streams, callbacks, file handles, or stores.
+- **Why it matters:** checkpoint outputs must be serializable.
+- **Action:** return strings, dicts, Pydantic dumps, IDs, or explicit artifact
+  references.
+
+### Secrets in config, metadata, or state
+
+- **Severity:** `BLOCKER`.
+- **Pattern:** API keys or tokens in `config`, `configurable`, request metadata,
+  graph state, or logs.
+- **Why it matters:** these values may become durable records.
+- **Action:** use environment variables or secret managers; keep secrets out of
+  Kitaru request metadata and artifacts.
+
+## Required report entry shape
+
+```markdown
+- Severity: HIGH
+- Source location: path/to/graph.py:123
+- Pattern: `checkpoint_strategy="calls"` but no `KitaruLangGraphMiddleware`
+- Migration action: switched to `graph_call` / not auto-migrated
+- Why it matters: without middleware, Kitaru cannot create granular call checkpoints
+- Required human decision: install middleware or accept one outer graph checkpoint
+```
+
+## Code comment shape
+
+```python
+# TODO(migration): This graph uses InMemorySaver but is expected to resume after
+# process restarts. Replace it with a durable LangGraph checkpointer before
+# claiming production restart durability.
+```

--- a/skills/kitaru-langgraph-migration/references/report-template.md
+++ b/skills/kitaru-langgraph-migration/references/report-template.md
@@ -1,0 +1,166 @@
+# Migration Report: LangGraph to Kitaru Adapter
+
+Use this template for `MIGRATION_REPORT.md` or for a report section in the final
+answer when the user does not want a file written.
+
+## Summary
+
+- Source framework: LangGraph / LangChain / Deep Agents
+- Target adapter: `kitaru.adapters.langgraph.KitaruGraphRunner`
+- Source files reviewed:
+  - `[path]`
+- Files changed or proposed:
+  - `[path]`
+- Migration status: `[complete / partial / plan only / blocked]`
+- Classification totals:
+  - Direct: `[n]`
+  - Approximate: `[n]`
+  - Absent: `[n]`
+  - Flagged: `[n]`
+  - Blocked: `[n]`
+
+## Source Pattern Inventory
+
+| Source location | Pattern found | Classification | Severity | Notes |
+|---|---|---|---|---|
+| `[file:line]` | `graph.invoke(...)` | `direct` | `LOW` | Replaced with `KitaruGraphRunner.invoke(...)`. |
+| `[file:line]` | `[pattern]` | `[direct / approximate / absent]` | `[LOW / MEDIUM / HIGH / BLOCKER]` | `[concrete note]` |
+
+## Chosen Kitaru Boundaries
+
+Describe the save points in plain language.
+
+Example:
+
+- The existing LangGraph graph remains the graph runtime.
+- `KitaruGraphRunner` is constructed once with a stable name.
+- The workflow uses `checkpoint_strategy="graph_call"`, so one completed or
+  interrupted `graph.invoke(...)` becomes one Kitaru checkpoint.
+- LangGraph checkpointers and `thread_id` remain responsible for graph-local
+  state and resume.
+
+## Direct Translations
+
+| Source | Target | Why direct |
+|---|---|---|
+| `graph.invoke(input, config=config)` | `runner.invoke(LangGraphRunRequest.start(input, thread_id=...))` | Same graph invocation; Kitaru changes the outer doorway. |
+| `[source]` | `[target]` | `[reason]` |
+
+## Approximate Translations
+
+| Source | Target | Behavior difference | Verification step |
+|---|---|---|---|
+| `create_agent(..., middleware=[...])` | Add `KitaruLangGraphMiddleware()` and use `calls` | Only synchronous middleware-visible model/tool calls become true Kitaru checkpoints. | Run a small sync model/tool call and inspect artifacts/events. |
+| `[source]` | `[target]` | `[difference]` | `[step]` |
+
+## Flagged for Human Review
+
+| Severity | Source location | Issue | What could break | Required action |
+|---|---|---|---|---|
+| `HIGH` | `[file:line]` | `[issue]` | `[duplicate side effect / lost resume / metadata-only boundary / etc.]` | `[review or redesign step]` |
+
+## Adapter-Specific Notes
+
+### Graph identity and names
+
+- Graph runner name: `[name]`
+- Names added or changed: `[names]`
+- Risk: changing names later can make old Kitaru execution history harder to
+  find.
+
+### `thread_id` and LangGraph persistence
+
+- Stable `thread_id` source: `[how generated/stored]`
+- Checkpointer found: `[yes/no/type]`
+- Store/memory found: `[yes/no/type]`
+- In-memory persistence caveat: `[not applicable / local-only / needs durable replacement]`
+
+### Checkpoint strategy
+
+- Chosen strategy: `[graph_call / calls]`
+- Reason:
+  - `[why this boundary is safe for this workflow]`
+- Replay consequence:
+  - `[what re-runs after a crash and what is served from Kitaru cache]`
+
+### Interrupts and resume
+
+- Uses `interrupt(...)`: `[yes/no]`
+- Resume mechanism found: `[Command(resume=...) / build_resume_request / other]`
+- Result status handling added: `[yes/no]`
+- Human wait bridge required: `[yes/no]`
+
+### Middleware and calls mode
+
+- Uses LangChain `create_agent(...)`: `[yes/no]`
+- `KitaruLangGraphMiddleware` installed: `[yes/no/not applicable]`
+- Sync model/tool call checkpoints expected: `[yes/no]`
+- Async calls caveat: `[metadata-only / not applicable]`
+
+### Streams, callbacks, and observability
+
+- Uses `stream` / `astream` / `stream_events`: `[yes/no/list]`
+- External stream/callback side effects: `[none known / needs review]`
+- Replay note:
+  - `[events are observability, not Kitaru replay boundaries]`
+
+### Deep Agents
+
+- Deep Agents features found: `[yes/no/list]`
+- Filesystem/sandbox/backend state note:
+  - `[what remains Deep Agents-owned]`
+
+## Behavioral Differences
+
+Explain concrete differences introduced by the migration.
+
+Examples:
+
+- "The source previously entered LangGraph directly. The migrated code enters the
+  same graph through `KitaruGraphRunner`, so Kitaru can record one outer graph
+  invocation result."
+- "LangGraph checkpointers still hold graph-local state. Kitaru does not replace
+  them."
+- "Callbacks and event streams remain observability paths. They are not replayed
+  as separate Kitaru checkpoints."
+
+## What Is Not Migrated
+
+| Item | Reason | Recommended redesign |
+|---|---|---|
+| `[item]` | `[why absent or unsafe]` | `[redesign]` |
+
+## Verification Plan
+
+- Static checks:
+  - `[imports resolve / stable runner name / stable thread_id / status checks]`
+- Local dry-run:
+  - `[small graph command or not run]`
+- Provider-backed run:
+  - `[command or not run because credentials unavailable]`
+- Kitaru behavior checks:
+  - Confirm execution appears in dashboard or `kitaru executions list`.
+  - Confirm expected `graph_call` or middleware-visible `calls` boundaries.
+  - Confirm interrupted runs resume through LangGraph state.
+  - Confirm replay does not duplicate unsafe side effects.
+
+## Docs and Reference Links
+
+- Kitaru LangGraph adapter docs:
+  `kitaru/docs/content/docs/adapters/langgraph.mdx`
+- Kitaru LangGraph adapter exports:
+  `kitaru/src/kitaru/adapters/langgraph/__init__.py`
+- Kitaru LangChain middleware:
+  `kitaru/src/kitaru/adapters/langgraph/langchain.py`
+- Skill references:
+  - `skills/kitaru-langgraph-migration/references/concept-map.md`
+  - `skills/kitaru-langgraph-migration/references/code-patterns.md`
+  - `skills/kitaru-langgraph-migration/references/gaps-and-flags.md`
+
+## Recommended Next Steps
+
+1. `[Run local graph dry-run / provider-backed smoke test]`
+2. `[Review HIGH/BLOCKER items]`
+3. `[Decide whether graph_call or calls is the long-term default]`
+4. `[Add project-specific tests for interrupts, replay, and side effects]`
+5. `[Update user-facing docs or examples if this migration changes public behavior]`

--- a/skills/kitaru-openai-agents-migration/SKILL.md
+++ b/skills/kitaru-openai-agents-migration/SKILL.md
@@ -78,7 +78,7 @@ Do not use it to:
 - Rewrite the user's agent into a different framework.
 - Claim Kitaru owns OpenAI Agents SDK internals.
 - Add LangGraph, Claude Agent SDK, Gemini Interactions, or PydanticAI migration
-  behavior.
+  behavior; use the matching sibling migration skill instead.
 - Hide replay, state, privacy, or side-effect risks just to produce cleaner
   code.
 - Put Kitaru `wait()` calls inside checkpoints.

--- a/skills/kitaru-openai-agents-migration/references/report-template.md
+++ b/skills/kitaru-openai-agents-migration/references/report-template.md
@@ -201,12 +201,12 @@ List anything intentionally left unchanged or blocked.
 - Skill gaps and flags:
   `skills/kitaru-openai-agents-migration/references/gaps-and-flags.md`
 
-## Deferred Adapter Migration Work
+## Other Adapter Migration Skills
 
-LangGraph, Claude Agent SDK, and Gemini Interactions migration skills are not
-part of this migration. Track deferred adapter migration work at
-https://github.com/zenml-io/kitaru-skills/issues/9 rather than creating
-placeholder directories or claiming those skills exist.
+LangGraph, Claude Agent SDK, Gemini Interactions, and PydanticAI migrations are
+not part of this OpenAI Agents SDK migration. Use the matching sibling skill:
+`kitaru-langgraph-migration`, `kitaru-claude-agent-sdk-migration`,
+`kitaru-gemini-interactions-migration`, or `kitaru-pydantic-ai-migration`.
 
 ## Recommended Next Steps
 

--- a/skills/kitaru-pydantic-ai-migration/SKILL.md
+++ b/skills/kitaru-pydantic-ai-migration/SKILL.md
@@ -66,7 +66,8 @@ Do not use this skill for:
 
 - OpenAI Agents SDK code using `agents.Agent` or `Runner.run(...)`; use the
   OpenAI Agents migration skill instead.
-- LangGraph, Claude Agent SDK, Gemini, or raw LangChain migrations.
+- LangGraph, Claude Agent SDK, Gemini Interactions, or raw LangChain migrations;
+  use the matching sibling migration skill instead.
 - Rewriting PydanticAI internals or provider-owned native tool behavior.
 - Promising exact replay of side effects that happen outside a Kitaru checkpoint
   boundary.

--- a/skills/kitaru-pydantic-ai-migration/references/report-template.md
+++ b/skills/kitaru-pydantic-ai-migration/references/report-template.md
@@ -174,11 +174,12 @@ List anything deliberately left unchanged or blocked.
   - `skills/kitaru-pydantic-ai-migration/references/code-patterns.md`
   - `skills/kitaru-pydantic-ai-migration/references/gaps-and-flags.md`
 
-## Deferred Adapter Migration Work
+## Other Adapter Migration Skills
 
-This report covers only PydanticAI to Kitaru's PydanticAI adapter. LangGraph,
-Claude Agent SDK, Gemini Interactions, and other adapter migration skills are
-separate work tracked in https://github.com/zenml-io/kitaru-skills/issues/9.
+This report covers only PydanticAI to Kitaru's PydanticAI adapter. For other
+frameworks, use the matching sibling skill: `kitaru-openai-agents-migration`,
+`kitaru-langgraph-migration`, `kitaru-claude-agent-sdk-migration`, or
+`kitaru-gemini-interactions-migration`.
 
 ## Recommended Next Steps
 

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -13,8 +13,9 @@ description: >-
   waits, needs to choose between SDK / KitaruClient / CLI / MCP control
   surfaces, asks how to handle state across executions, or arrives with a
   workflow that might be too simple or too complex for Kitaru, or needs to
-  choose among PydanticAI, OpenAI Agents, LangGraph, and Claude Agent SDK
-  adapter boundaries. Also use when the user says "I want to build an agent"
+  choose among PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and
+  Gemini Interactions adapter boundaries. Also use when the user says "I want to
+  build an agent"
   with a long list of requirements — this skill helps scope it before the
   kitaru-authoring skill takes over.
 ---
@@ -62,13 +63,14 @@ user-facing surfaces:
   metadata-only secret creation, local-server/status/stack tools, and
   `manage_stack`.
 
-It also ships four adapter families. Scope them as design choices, not as one
+It also ships five adapter families. Scope them as design choices, not as one
 universal answer:
 
 - **PydanticAI** — `KitaruAgent` for durable PydanticAI runs and tool/MCP calls
 - **OpenAI Agents** — `KitaruRunner` for OpenAI Agents SDK runs
 - **LangGraph** — `KitaruGraphRunner` for graph calls or middleware-observed sync calls
 - **Claude Agent SDK** — `KitaruClaudeRunner` for whole Claude SDK invocations
+- **Gemini Interactions** — `KitaruGeminiInteractionsRunner` for stable Gemini Interactions responses
 
 `wrap(...)` still exists as a deprecated PydanticAI migration shim, but new
 designs should use `KitaruAgent(...)` directly.
@@ -421,6 +423,18 @@ Kitaru replay boundaries. If a file write or API call must be durable, put that
 side effect in its own Kitaru checkpoint after Claude returns. Claude session
 resume and Claude file checkpointing are Claude SDK features, not Kitaru replay.
 
+### Gemini Interactions / `KitaruGeminiInteractionsRunner`
+
+Use `KitaruGeminiInteractionsRunner(...)` when a stable Gemini Interactions
+response should become one Kitaru checkpoint. Stable means `completed` or
+`requires_action`. Scope `requires_action` as a handoff back to the Kitaru flow:
+local tool work or human approval should happen in flow scope, then a later
+`function_result` request continues the interaction. Google-owned hosted tools,
+MCP, web/code execution, managed-agent steps, and Antigravity
+sandbox/environment/filesystem internals are not granular Kitaru replay
+boundaries. If project, region, credentials, or client configuration can change
+results, include a `cache_identity` decision in the architecture.
+
 ## Phase 7: Check anti-patterns
 
 Review the proposed design for these smells:
@@ -442,6 +456,14 @@ Review the proposed design for these smells:
 - LangGraph designs that assume Kitaru replaces the graph checkpointer/store
 - Claude Agent SDK designs that expect granular replay of Claude-internal Bash,
   MCP, custom tool, hook, permission, or workspace side effects
+- Gemini Interactions designs that treat Google-owned hosted tools, MCP,
+  web/code execution, managed-agent steps, or Antigravity sandbox/filesystem
+  internals as replayable Kitaru checkpoints
+- Gemini Interactions designs that hide `requires_action` work inside the
+  provider-owned interaction instead of returning local tool or human work to
+  Kitaru flow scope
+- Antigravity designs that assume remote environments provide Kitaru-owned
+  filesystem durability or replayable sandbox state
 - designs that expect Kitaru to provide native durable key-value state
 - cross-flow artifact designs with no plan for how downstream flows receive
   upstream execution IDs


### PR DESCRIPTION
## What changed

Adds the three remaining Kitaru migration skills requested in issue #9:

- `kitaru-langgraph-migration`
- `kitaru-claude-agent-sdk-migration`
- `kitaru-gemini-interactions-migration`

Each new skill follows the existing conservative migration pattern: inspect source first, classify patterns as `direct` / `approximate` / `absent`, choose an honest Kitaru boundary, plan before risky edits, and produce a migration report.

This also updates README, AGENTS/CLAUDE guidance, Claude plugin metadata, and authoring/scoping skills so the package consistently advertises eight skills and all five adapter families.

Fixes #9.

## Reviewer Notes

The important story is boundary honesty. LangGraph can be either an outer `graph_call` checkpoint or sync LangChain model/tool calls when `KitaruLangGraphMiddleware()` physically wraps the handler. Claude Agent SDK stays intentionally coarse: one completed invocation is one checkpoint. Gemini Interactions also stays coarse: one stable interaction response is one checkpoint, with `requires_action` returning work to Kitaru flow scope.

Please focus review on whether the new migration skills avoid overclaiming replay of framework/provider internals. The highest-risk areas are the new `code-patterns.md` and `gaps-and-flags.md` files, because future agents will copy those examples and severity labels when migrating user code.

### Reproduction

1. Inspect the public inventory:
   - `README.md`
   - `AGENTS.md`
   - `CLAUDE.md`
   - `.claude-plugin/plugin.json`
   - `.claude-plugin/marketplace.json`
2. Confirm all eight skills are listed and plugin version fields are synchronized at `0.7.0`.
3. Review one new skill end to end, for example:
   - `skills/kitaru-langgraph-migration/SKILL.md`
   - `skills/kitaru-langgraph-migration/references/concept-map.md`
   - `skills/kitaru-langgraph-migration/references/code-patterns.md`
   - `skills/kitaru-langgraph-migration/references/gaps-and-flags.md`
   - `skills/kitaru-langgraph-migration/references/report-template.md`
4. Check that the same five-file structure exists for Claude Agent SDK and Gemini Interactions.
5. Confirm adjacent guidance now includes Gemini Interactions:
   - `skills/kitaru-authoring/SKILL.md`
   - `skills/kitaru-scoping/SKILL.md`

Local checks run:

- `jq . .claude-plugin/plugin.json`
- `jq . .claude-plugin/marketplace.json`
- `git diff --check`
- targeted `rg` checks for stale issue #9/deferred wording, five/eight inventory drift, unsafe replay claims, old problematic example forms
- Markdown fence/table shape checks via validation agent
- Oracle review loop until no P1/P2 blockers remained
