### PR TITLE
Align skill prose with Kitaru messaging canon v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are nine Markdown skills plus quickstart and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
+This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's replay-and-regression layer for agents, built on a durable execution foundation for Python workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are nine Markdown skills plus quickstart and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
 
 Claude Code distribution is supported through the `.claude-plugin/` metadata and the Claude Code marketplace entry `zenml-io/kitaru-skills`.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Kitaru Agent Skills
 
 Reusable Markdown agent skills for discovering, designing, migrating, and
-building durable AI agent workflows with [Kitaru](https://kitaru.ai).
+building agent workflows with [Kitaru](https://kitaru.ai) — the
+replay-and-regression layer for agents.
+
+Observability tools watch your agent. Kitaru turns your production traces into
+a faithful environment you can re-run — so when you change your agent, you
+catch what breaks before your users do. Durable checkpoints, waits, and resume
+are the foundation that replay is built on.
 
 This repository contains nine shared skill directories plus Claude Code plugin
 packaging. Claude Code can install the skills through its plugin flow. Codex,

--- a/skills/kitaru-quickstart/SKILL.md
+++ b/skills/kitaru-quickstart/SKILL.md
@@ -15,6 +15,11 @@ Build and run a working Kitaru demo tailored to the user's domain. Take
 someone from "I've heard of Kitaru" to "I understand crash recovery, replay,
 waits, artifacts, and the dashboard" in a single teaching session.
 
+When narrating, frame the payoff canon-consistently: durable checkpoints and
+waits are the foundation, not the pitch. The point is that Kitaru records real
+runs faithfully enough that you can change your agent and re-run the change
+against what actually happened — and catch what breaks before your users do.
+
 > **Relationship to other skills**:
 > - `kitaru-quickstart` (`/kitaru-quickstart` in Claude Code) → activation and intuition (this skill)
 > - `kitaru-scoping` (`/kitaru-scoping` in Claude Code) → design durability for a real workflow
@@ -247,7 +252,7 @@ Tell the user:
 > everything before that crash is just gone unless you built your own save
 > system. With Kitaru, checkpoint 1 is already persisted. Think of it like a
 > video game save point: we can fix the bug and resume from the save instead
-> of replaying the whole level."
+> of playing the whole level again."
 
 ### Step 6: Fix the code
 
@@ -307,8 +312,10 @@ Tell the user:
 
 > "The important thing is not just that the code ran after the fix. The
 > important thing is where it restarted. Kitaru kept the completed checkpoint
-> and replayed from the named boundary. That's the durable-execution trick:
-> no burned tokens, no repeated API calls, no lost progress."
+> and re-ran your fix from the named boundary against the record of the failed
+> run — no burned tokens, no repeated API calls, no lost progress. Durable
+> checkpoints are the foundation; the payoff is what you just did: change the
+> code and re-run the change against what really happened."
 
 **Verification**: If replay fails, read the full output. First retry with the
 `PYTHONPATH=.` CLI command above. If that also fails, stop and present the

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -45,8 +45,10 @@ Your value is to turn that fog into a practical architecture.
 
 ## What Kitaru is
 
-Kitaru is a durable execution layer for Python workflows built around four
-user-facing surfaces:
+Kitaru is **the replay-and-regression layer for agents.** It records real
+executions faithfully enough that a change can be re-run against what actually
+happened. That fidelity rests on a durable execution foundation for Python
+workflows, exposed through four user-facing surfaces:
 
 - **SDK primitives**: `@flow`, `@checkpoint`, `wait()`, `log()`, `save()`,
   `load()`, `llm()`, `current_execution_id()`, plus configuration helpers,

--- a/skills/kitaru-scoping/SKILL.md
+++ b/skills/kitaru-scoping/SKILL.md
@@ -498,7 +498,7 @@ The MVP should usually have:
   neither)
 - a small set of stable replay anchors (`at` selectors) and an intended
   override strategy
-- output that is genuinely useful on its own
+- output that is useful on its own
 
 If the user asks for a huge autonomous platform, help them carve out the first
 valuable flow instead of agreeing to build the whole city at once.


### PR DESCRIPTION
## Summary
Positioning pass over the skill prose per the Kitaru messaging canon v3: lead copy moves from "durable execution layer" to the replay-and-regression category, with durability subordinated as foundation. Frontmatter `description:` fields are deliberately byte-untouched to preserve skill triggering.

## What changed
- **README.md**: lead now carries the §1 category and the §2 crux LOCK verbatim, closing with durability-as-foundation.
- **CLAUDE.md**: IS-statement → "ZenML's replay-and-regression layer for agents, built on a durable execution foundation for Python workflows".
- **skills/kitaru-scoping/SKILL.md**: "What Kitaru is" opens with the §1 LOCK verbatim; four-surfaces list intact.
- **skills/kitaru-quickstart/SKILL.md**: canon-framing note for narration; Step 5 no longer uses "replaying" colloquially; Step 9 narration is outcome-led.

## What reviewers should focus on
- LOCK lines must stay character-identical to the canon — don't copy-edit them.
- No frontmatter changed anywhere (verified via git diff) — trigger keywords are untouched. API names (`flow.replay`, `kitaru executions replay`) intentionally unchanged.

## Validation
Byte-level LOCK verification against the canon; adversarial fresh-eyes review against the rollout DONE checks — all pass; frontmatter integrity verified with `git diff -U0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## TODO (follow-ups, not blocking review)
- [ ] Separate pass on SKILL.md frontmatter `description:` fields with triggering evals (positioning language like "durable execution model" / "crash recovery with replay" left untouched here to avoid trigger regressions) — update the mirrored README/CLAUDE.md skill-table blurbs together with it
- [ ] Canon-owner ruling on replay-vs-resume for the crash-recovery prose (the quickstart recovery flow genuinely uses the `replay` API)
- [ ] Consider re-leading the quickstart demo arc (currently crash-recovery-first) around "change your agent, re-run against the failed run" per §9 — content redesign, not a copy pass
