### PR TITLE
Add Langfuse trace-to-test skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,8 +6,8 @@
     "url": "https://zenml.io"
   },
   "metadata": {
-    "description": "Eight Kitaru Agent Skills for quickstart onboarding, durable flow scoping, authoring with current adapter families, and conservative migrations for PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, and Gemini Interactions",
-    "version": "0.7.0",
+    "description": "Nine Kitaru Agent Skills for onboarding, durable flow design, authoring, visual Langfuse trace-to-test investigations, and conservative framework migrations",
+    "version": "0.8.0",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
   },
@@ -15,8 +15,8 @@
     {
       "name": "kitaru",
       "source": "./",
-      "description": "Claude Code package bundling eight Kitaru Agent Skills: kitaru-quickstart (beginner onboarding with crash recovery, wait(), artifacts, dashboard, and optional MCP), kitaru-scoping (durable flow architecture and adapter boundary choices), kitaru-authoring (flows, checkpoints, waits, KitaruClient, deployments, secrets, CLI/MCP, and current adapters), kitaru-pydantic-ai-migration (PydanticAI to KitaruAgent), kitaru-openai-agents-migration (OpenAI Agents SDK to KitaruRunner), kitaru-langgraph-migration (LangGraph/LangChain to KitaruGraphRunner), kitaru-claude-agent-sdk-migration (Claude Agent SDK to KitaruClaudeRunner), and kitaru-gemini-interactions-migration (Gemini Interactions/Antigravity to KitaruGeminiInteractionsRunner).",
-      "version": "0.7.0",
+      "description": "Claude Code package bundling nine Kitaru Agent Skills for onboarding, scoping, authoring, visual Langfuse trace-to-test replay investigations, and migrations for PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, and Gemini Interactions.",
+      "version": "0.8.0",
       "author": {
         "name": "ZenML",
         "url": "https://kitaru.ai"
@@ -33,6 +33,10 @@
         "agent-workflows",
         "checkpoints",
         "human-in-the-loop",
+        "langfuse",
+        "imported-replay",
+        "regression-gate",
+        "ci",
         "migration",
         "adapter-migration",
         "pydantic-ai",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
-  "description": "Claude Code distribution for eight Kitaru Agent Skills: quickstart onboarding, durable flow scoping, authoring with current adapters, and conservative migrations for PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, and Gemini Interactions",
-  "version": "0.7.0",
+  "description": "Claude Code distribution for nine Kitaru Agent Skills: quickstart onboarding, durable flow scoping, authoring with current adapters, visual Langfuse trace-to-test investigations, and conservative framework migrations",
+  "version": "0.8.0",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"
@@ -17,6 +17,10 @@
     "workflows",
     "checkpoints",
     "human-in-the-loop",
+    "langfuse",
+    "imported-replay",
+    "regression-gate",
+    "ci",
     "migration",
     "adapter-migration",
     "pydantic-ai",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This repository contains **Kitaru Agent Skills** plus Claude Code plugin metadat
 - `skills/kitaru-langgraph-migration/SKILL.md` defines the LangGraph migration skill.
 - `skills/kitaru-claude-agent-sdk-migration/SKILL.md` defines the Claude Agent SDK migration skill.
 - `skills/kitaru-gemini-interactions-migration/SKILL.md` defines the Gemini Interactions migration skill.
+- `skills/kitaru-trace-to-test/SKILL.md` defines the user-invoked Langfuse trace-to-regression workflow.
 - `.claude-plugin/plugin.json` contains Claude Code plugin metadata such as name, version, and repository URL.
 - `.claude-plugin/marketplace.json` defines the Claude Code marketplace entry used for local/plugin testing.
 - `README.md` is the public-facing usage, installation, and host guidance.
@@ -26,7 +27,7 @@ There is no build step in this repo. Most contributor work is editing Markdown a
 - `git diff --stat` gives a compact review of changed files.
 - `jq . .claude-plugin/plugin.json` validates plugin JSON formatting if `jq` is installed.
 
-For manual Claude Code smoke testing, follow the install commands in [`README.md`](README.md) and verify the Claude Code distribution route exposes `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`, `/kitaru-openai-agents-migration`, `/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`, and `/kitaru-gemini-interactions-migration`.
+For manual Claude Code smoke testing, follow the install commands in [`README.md`](README.md) and verify the Claude Code distribution route exposes `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`, `/kitaru-openai-agents-migration`, `/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`, `/kitaru-gemini-interactions-migration`, and `/kitaru-trace-to-test`.
 
 ## Coding Style & Naming Conventions
 Use Markdown for prose and JSON for Claude Code plugin metadata. Match the existing style:
@@ -57,6 +58,7 @@ before editing skill prose:
 
 - Adapter exports under `kitaru/src/kitaru/adapters/*/__init__.py`
 - Current adapter guides for PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini Interactions
+- Current Langfuse import, imported replay, scoring, protection, verdict, experiment, and regression-limit contracts
 - MCP server docs for current tool names and categories
 - `CHANGELOG.md` and `pyproject.toml` for release facts and removed APIs
 - Skill inventory, portable skill names, and Claude Code slash command names across README, AGENTS, CLAUDE, metadata, and frontmatter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are eight Markdown skills plus quickstart and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
+This repository contains **Kitaru Agent Skills** for [Kitaru](https://kitaru.ai) — ZenML's durable execution layer for Python agent workflows — plus Claude Code plugin packaging. It contains no application code; the deliverables are nine Markdown skills plus quickstart, replay, and migration references that teach agent hosts how to onboard, scope, author, and migrate Kitaru workflows.
 
 Claude Code distribution is supported through the `.claude-plugin/` metadata and the Claude Code marketplace entry `zenml-io/kitaru-skills`.
 
@@ -24,6 +24,7 @@ skills/
   kitaru-langgraph-migration/       # LangGraph to KitaruGraphRunner migration skill + references
   kitaru-claude-agent-sdk-migration/ # Claude Agent SDK to KitaruClaudeRunner migration skill + references
   kitaru-gemini-interactions-migration/ # Gemini Interactions to KitaruGeminiInteractionsRunner migration skill + references
+  kitaru-trace-to-test/             # Langfuse trace to visual replay evidence and CI gate
 ```
 
 - **kitaru-quickstart** (`/kitaru-quickstart` in Claude Code) — interactive onboarding that scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration.
@@ -34,12 +35,13 @@ skills/
 - **kitaru-langgraph-migration** (`/kitaru-langgraph-migration` in Claude Code) — conservative migration guide for existing LangGraph/LangChain code moving to `KitaruGraphRunner`, with `graph_call` vs middleware-backed `calls` boundary reporting.
 - **kitaru-claude-agent-sdk-migration** (`/kitaru-claude-agent-sdk-migration` in Claude Code) — conservative migration guide for existing Claude Agent SDK code moving to `KitaruClaudeRunner`, with one-invocation checkpointing and Claude-owned tool/Bash/MCP/workspace caveats.
 - **kitaru-gemini-interactions-migration** (`/kitaru-gemini-interactions-migration` in Claude Code) — conservative migration guide for existing Gemini Interactions, Google GenAI Interactions, or Antigravity managed-agent code moving to `KitaruGeminiInteractionsRunner`, with `requires_action`, polling, function-result, and Google-owned internals reporting.
+- **kitaru-trace-to-test** (`/kitaru-trace-to-test` in Claude Code): user-invoked visual workflow that turns one selected Langfuse trace into safe PydanticAI replay evidence, a bounded experiment, and a proposed CI gate.
 
-The intended user workflow is: quickstart → scope → author for new work, or migration skill → report review → author for existing PydanticAI, OpenAI Agents SDK, LangGraph, Claude Agent SDK, or Gemini Interactions code.
+The intended user workflow is: quickstart → scope → author for new work; migration skill → report review → author for existing framework code; or trace-to-test for a production incident already captured in Langfuse.
 
 ## How to work on this repo
 
-There is no build step, no linter, no test suite. The deliverables are the eight `SKILL.md` files plus the quickstart and migration reference files. Quality comes from:
+There is no build step, no linter, no test suite. The deliverables are the nine `SKILL.md` files plus the quickstart and migration reference files. Quality comes from:
 
 1. **Accuracy against the Kitaru SDK** — every primitive, API surface, and constraint described in the skills must match the current Kitaru release. Cross-reference with the [Kitaru SDK repo](https://github.com/zenml-io/kitaru) and [docs](https://kitaru.ai/docs).
 2. **Completeness of asymmetry tables** — the skills document capability differences across SDK, KitaruClient, CLI, MCP, deployments, secrets, and adapter surfaces. These tables must stay synchronized between the scoping and authoring skills.
@@ -47,8 +49,8 @@ There is no build step, no linter, no test suite. The deliverables are the eight
 
 ## Key constraints when editing skills
 
-- The SKILL.md frontmatter (`name`, `description`) is what Claude Code uses for skill matching and trigger detection. Keep trigger keywords accurate.
-- All eight skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored where relevant.
+- The SKILL.md frontmatter controls skill identity and invocation. Keep user-invoked skills explicit and model-invoked trigger descriptions accurate.
+- All nine skills share the same Kitaru domain model (surfaces, asymmetries, guardrails). Changes to one skill's representation of a constraint (e.g., "waits cannot go inside checkpoints") should be mirrored where relevant.
 - The authoring skill's "common mistakes checklist" and the scoping skill's "anti-patterns" section overlap intentionally — they serve different audiences (implementer vs architect).
 - The quickstart skill's track templates in `references/tracks/` must use only real, documented Kitaru APIs. Template decorator placement is fixed; only internal business logic is customizable.
 - Native durable memory APIs were removed in Kitaru 0.11.0. Do not reintroduce old native-memory wording or recommend a Kitaru-owned durable key-value state API. Use external/application-owned stores for mutable cross-execution state and pass explicit values or stable references into flows.
@@ -71,4 +73,5 @@ cp -R skills/kitaru-openai-agents-migration .claude/skills/
 cp -R skills/kitaru-langgraph-migration .claude/skills/
 cp -R skills/kitaru-claude-agent-sdk-migration .claude/skills/
 cp -R skills/kitaru-gemini-interactions-migration .claude/skills/
+cp -R skills/kitaru-trace-to-test .claude/skills/
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Reusable Markdown agent skills for discovering, designing, migrating, and
 building durable AI agent workflows with [Kitaru](https://kitaru.ai).
 
-This repository contains eight shared skill directories plus Claude Code plugin
+This repository contains nine shared skill directories plus Claude Code plugin
 packaging. Claude Code can install the skills through its plugin flow. Codex,
 Cursor, and other agent hosts can use the Markdown skill files and the
 host-specific MCP setup guides where their local skill, rule, or context-loading
@@ -16,6 +16,7 @@ workflow supports that pattern.
 | **kitaru-quickstart** | `kitaru-quickstart` (`/kitaru-quickstart` in Claude Code) | Interactive onboarding: scaffolds a personalized demo flow, demonstrates crash recovery with replay, human-in-the-loop with `wait()`, artifact capture, and optional MCP integration |
 | **kitaru-scoping** | `kitaru-scoping` (`/kitaru-scoping` in Claude Code) | Structured interview to validate whether your workflow benefits from durable execution, then designs the flow architecture (checkpoint boundaries, wait points, replay anchors, artifact strategy, operator surface, MVP scope) |
 | **kitaru-authoring** | `kitaru-authoring` (`/kitaru-authoring` in Claude Code) | Guide for writing Kitaru flows, checkpoints, waits, logging, artifacts, `KitaruClient`, replay/resume/retry, deployments, secrets, CLI/MCP tools, and adapters for PydanticAI, OpenAI Agents, LangGraph, Claude Agent SDK, and Gemini Interactions |
+| **kitaru-trace-to-test** | `kitaru-trace-to-test` (`/kitaru-trace-to-test` in Claude Code) | User-invoked visual investigation that turns one selected Langfuse trace into a safe PydanticAI replay experiment, bounded rerun, and proposed CI regression gate |
 | **kitaru-pydantic-ai-migration** | `kitaru-pydantic-ai-migration` (`/kitaru-pydantic-ai-migration` in Claude Code) | Migrate existing PydanticAI agent code to `KitaruAgent` with conservative boundary selection, direct/approximate/absent classification, HITL safety checks, capture policy guidance, and a migration report |
 | **kitaru-openai-agents-migration** | `kitaru-openai-agents-migration` (`/kitaru-openai-agents-migration` in Claude Code) | Migrate existing OpenAI Agents SDK code to `KitaruRunner`, `OpenAIRunRequest`, and `OpenAIRunResult` with checkpoint strategy selection, approval/resume handling, context serialization checks, and a migration report |
 | **kitaru-langgraph-migration** | `kitaru-langgraph-migration` (`/kitaru-langgraph-migration` in Claude Code) | Migrate existing LangGraph, LangChain `create_agent(...)`, or Deep Agents-style code to `KitaruGraphRunner` with honest `graph_call` vs middleware-backed `calls` boundary selection and a migration report |
@@ -32,6 +33,15 @@ For new Kitaru work:
    architecture before writing code
 3. **Author** — use `kitaru-authoring` to build the flows defined in your
    `flow_architecture.md`
+
+For a production incident captured in Langfuse:
+
+1. **Select the evidence:** invoke `kitaru-trace-to-test` with an exact trace
+   ID, trace URL, or observations JSONL export
+2. **Build the case file:** preview the import, validate replay boundaries,
+   compare the protected candidate, and inspect PASS, HOLD, or FAIL evidence
+3. **Mint the gate:** rerun the exact experiment under explicit limits and
+   prepare a PASS-only CI test
 
 For existing framework code:
 
@@ -51,8 +61,8 @@ For existing framework code:
 In Claude Code, those skills are exposed as slash commands:
 `/kitaru-quickstart`, `/kitaru-scoping`, `/kitaru-authoring`,
 `/kitaru-pydantic-ai-migration`, `/kitaru-openai-agents-migration`,
-`/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`, and
-`/kitaru-gemini-interactions-migration`.
+`/kitaru-langgraph-migration`, `/kitaru-claude-agent-sdk-migration`,
+`/kitaru-gemini-interactions-migration`, and `/kitaru-trace-to-test`.
 
 ## Installation and usage
 
@@ -66,12 +76,14 @@ marketplace:
 /plugin install kitaru@kitaru
 ```
 
-Once installed, Claude Code will automatically use the skills based on context.
-You can also invoke them explicitly with `/kitaru-quickstart`,
+Once installed, Claude Code can use model-invoked skills based on context.
+`kitaru-trace-to-test` is intentionally user-invoked because it can store trace
+content, make paid model calls, and propose CI changes. Invoke skills explicitly
+with `/kitaru-quickstart`,
 `/kitaru-scoping`, `/kitaru-authoring`, `/kitaru-pydantic-ai-migration`,
 `/kitaru-openai-agents-migration`, `/kitaru-langgraph-migration`,
-`/kitaru-claude-agent-sdk-migration`, or
-`/kitaru-gemini-interactions-migration`.
+`/kitaru-claude-agent-sdk-migration`, `/kitaru-gemini-interactions-migration`,
+or `/kitaru-trace-to-test`.
 
 For project/team installation, add this to your project's
 `.claude/settings.json`:
@@ -101,6 +113,7 @@ cp -R "$tmpdir/kitaru-skills/skills/kitaru-openai-agents-migration" .claude/skil
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-langgraph-migration" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-claude-agent-sdk-migration" .claude/skills/
 cp -R "$tmpdir/kitaru-skills/skills/kitaru-gemini-interactions-migration" .claude/skills/
+cp -R "$tmpdir/kitaru-skills/skills/kitaru-trace-to-test" .claude/skills/
 rm -rf "$tmpdir"
 ```
 
@@ -110,7 +123,7 @@ for MCP setup details.
 ### Codex usage
 
 Codex setup depends on the Codex version and local configuration style you use.
-If your Codex environment supports local skills, copy the eight
+If your Codex environment supports local skills, copy the nine
 `skills/kitaru-*` directories into the supported Codex skills location or load
 the relevant `SKILL.md` files as explicit project context.
 
@@ -136,6 +149,11 @@ ask the agent to follow it. This is the portable fallback path when the host doe
 not have a formal skill or plugin system.
 
 ## Example prompts
+
+**Trace to test:**
+- "Use kitaru-trace-to-test with this Langfuse trace ID and show me whether my candidate fix is safe."
+- "Turn this Langfuse observations export into a visual replay investigation and bounded regression gate."
+- "Run the trace-to-test demo mode, but pause before storing data or spending on model calls."
 
 **Quickstart:**
 - "I want to try Kitaru — show me what it does."

--- a/skills/kitaru-trace-to-test/SKILL.md
+++ b/skills/kitaru-trace-to-test/SKILL.md
@@ -79,7 +79,9 @@ verdict and actual spend
 CI test path and readiness
 ```
 
-Keep prompts, observation payloads, customer data, tool arguments, tool results,
+Permit approved project-relative source entrypoints and test paths because they
+identify the code under review. Keep absolute user paths, trace-derived paths,
+prompts, observation payloads, customer data, tool arguments, tool results,
 credentials, and secrets out of the case file and visual report.
 
 ## Phase 0: Establish the agent under test
@@ -118,8 +120,11 @@ Resolve the source as one of:
 - Langfuse observations JSONL;
 - read-only discovery through a host-provided Langfuse or browser integration.
 
-For JSONL, enumerate trace identities without writing. For remote Langfuse
-without an exact ID, explain that Kitaru cannot discover traces, show the
+For JSONL, enumerate trace identities without writing. Preserve the selected
+trace with `--trace-id <selected-trace-id>` in preview and write commands. For
+remote Langfuse, verify the supported `kitaru[langfuse]` dependency before
+requesting credentials. Without an exact ID, explain that Kitaru cannot discover
+traces, show the
 candidate criteria from the adaptation contract, and help the user select in
 Langfuse.
 
@@ -140,7 +145,7 @@ Never guess or infer a remote trace ID.
 
 Run Kitaru's dry-run preview first. Validate:
 
-- exactly the selected trace appears;
+- exactly one trace is selected and its ID equals the chosen trace;
 - source attribution is verified or explicitly caller-attributed;
 - no version conflict or rejected outcome exists;
 - graph integrity and fragmentation are disclosed;
@@ -154,9 +159,9 @@ be stored, the stack's reported storage accessibility, and that importing calls
 neither the model nor the agent's tools. Show message-history boundary status as
 HOLD with `adapter validation pending`.
 
-Pause for explicit storage consent. Only then reuse the identical preview
-command and exact `--stack` selector, adding `--write` and
-`--confirm-data-storage`.
+Pause for explicit storage consent only when the preview reports
+`selected_trace_count == 1`. Then reuse the identical `--trace-id` and
+`--stack` selectors, adding `--write` and `--confirm-data-storage`.
 
 Accept a successful created, resumed, or unchanged outcome and capture the
 exact imported execution ID. Inspect it with the normal execution surface.
@@ -299,6 +304,19 @@ check returns the same stored attempt. Otherwise end STOPPED SAFELY.
 Read the CI reference. Propose deterministic scorer, protection, recorded-tool,
 boundary, and idempotency tests before the paid live gate.
 
+Before generating an enabled recurring gate, obtain standing CI authorization
+with a visual card that shows:
+
+- workflow triggers and expected run frequency;
+- the AgentVersion registration performed for each commit;
+- credential and provider scope;
+- maximum spend per run and estimated monthly or scheduled spend;
+- retry and idempotency behavior;
+- who can disable or change the gate.
+
+Without standing authorization, generate the live test disabled behind an
+explicit environment opt-in and credential skip.
+
 Generate the project-specific CI test only after showing:
 
 - exact target path;
@@ -307,8 +325,9 @@ Generate the project-specific CI test only after showing:
 - idempotency strategy;
 - objective and protections;
 - limits;
-- live-provider markers and credential behavior;
-- expected pull-request and scheduled-suite cost.
+- live-provider markers, explicit opt-in, and credential skip behavior;
+- expected pull-request and scheduled-suite cost;
+- whether recurring CI execution has standing authorization.
 
 Run the narrowest available non-live validation. Run the live gate only under a
 separate paid authorization unless it was included in the exact Phase 6
@@ -319,7 +338,9 @@ protection must make the containing CI job required before it blocks a merge.
 
 **Completion criterion:** the proposed or approved test targets the exact
 experiment, uses a commit-derived candidate version, explicit limits, a stable
-idempotency key, and `assert_pass()`. Report merge-gate wiring separately.
+idempotency key, `assert_pass()`, repository live markers, credential skipping,
+and an explicit opt-in unless recurring spend has standing authorization. Report
+merge-gate wiring and recurring authorization separately.
 
 ## Finish
 

--- a/skills/kitaru-trace-to-test/SKILL.md
+++ b/skills/kitaru-trace-to-test/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: kitaru-trace-to-test
+description: Turn one Langfuse incident trace into a safe Kitaru replay experiment and bounded CI regression gate.
+disable-model-invocation: true
+---
+
+# Kitaru Trace to Test
+
+Turn one production trace into a case file whose evidence can become a
+regression test. Advance through the evidence ladder one checked rung at a time:
+
+```text
+trace → verified import → validated boundary → reproduced control
+      → protected candidate → bounded rerun → CI gate
+```
+
+A run ends either **CI READY** or **STOPPED SAFELY**. A HOLD or FAIL is useful
+evidence, not an invitation to spend until the result changes.
+
+## Load the contracts progressively
+
+Read only the material needed for the current rung:
+
+1. Before the first update, read the evidence ladder and pause-card sections of
+   [references/visual-evidence.md](references/visual-evidence.md).
+2. In Phase 0, read the shipped/unsupported sections of
+   [references/capabilities.md](references/capabilities.md) and the inspection
+   section of
+   [references/project-adaptation.md](references/project-adaptation.md).
+3. In Phases 1 and 2, read trace selection and import commands.
+4. In Phase 3, read boundary validation plus the DAG and boundary visual rules.
+5. Before paid replay, read the verdict and cost visual rules.
+6. Read [references/ci-gate.md](references/ci-gate.md) only after a qualifying
+   candidate experiment.
+
+## Interaction mode
+
+Read `KITARU_TRACE_TO_TEST_MODE`.
+
+| Value | Behavior |
+|---|---|
+| unset, empty, or `guided` | Pause after trace selection, preview, boundary selection, candidate evidence, and proposed file changes. |
+| `demo` | Propose combining read-only findings and keeping narration tight. Confirm this mode in the first response before suppressing guided pauses. |
+| anything else | Explain the accepted values and use `guided`. |
+
+Demo mode reduces interruptions. It preserves these authorization gates:
+
+1. registering or reusing an AgentVersion;
+2. storing imported trace data;
+3. making each exact paid replay request;
+4. editing agent, scorer, protection, test, or CI files;
+5. proceeding when attribution, tool effects, or evidence validity is ambiguous.
+
+Use the user's structured question tool when available. Ask one decision per
+pause unless a paid-execution card fully identifies the trace, candidate,
+models, limits, and estimated spend.
+
+## Case file
+
+Keep resumable state in memory. If the run may cross sessions, offer a redacted
+temporary state file under
+`$TMPDIR/kitaru-trace-to-test/<case-slug>/state.json`. Write inside the
+project only with approval.
+
+Record:
+
+```text
+phase
+source kind and non-secret locator
+trace ID and selection reason
+agent and source version
+imported execution ID
+validated boundary identifiers
+candidate entrypoint and version
+objective and expected protection IDs
+approved trial, cost, token, and duration limits
+control, candidate, and rerun experiment IDs
+verdict and actual spend
+CI test path and readiness
+```
+
+Keep prompts, observation payloads, customer data, tool arguments, tool results,
+credentials, and secrets out of the case file and visual report.
+
+## Phase 0: Establish the agent under test
+
+Inspect repository instructions and the installed Kitaru version. Verify
+relevant CLI commands with local `--help` before executing them.
+
+Use the project-adaptation contract to locate the source agent, candidate,
+registration entrypoints, objective, protections, and tools. Classify every
+relevant tool as read, write, or unknown.
+
+Render:
+
+- the evidence ladder with only this rung active;
+- the adaptation table;
+- a tool-safety table;
+- a short explanation of what Kitaru will rerun in this agent.
+
+If a stable PydanticAI agent entrypoint, meaningful objective, or domain
+protection is missing, propose the smallest project change. Show the files and
+behavior before editing.
+
+Before calling `.register(...)`, show a registration pause card with the Kitaru
+project, agent name, immutable label, entrypoint, and whether registration will
+create or reuse an AgentVersion. Obtain approval for that persistent mutation.
+
+**Completion criterion:** every required item is READY, every relevant tool has
+a justified classification, and the user can see which agent behavior the
+future experiment will test. Otherwise end or continue diagnostic-only as HOLD.
+
+## Phase 1: Select one trace
+
+Resolve the source as one of:
+
+- exact Langfuse trace ID or URL;
+- Langfuse observations JSONL;
+- read-only discovery through a host-provided Langfuse or browser integration.
+
+For JSONL, enumerate trace identities without writing. For remote Langfuse
+without an exact ID, explain that Kitaru cannot discover traces, show the
+candidate criteria from the adaptation contract, and help the user select in
+Langfuse.
+
+Render a candidate table. Recommend one trace and explain:
+
+- what failed or warrants investigation;
+- what recorded tool evidence exists;
+- what remains for the candidate to decide;
+- why this trace is representative or incident-relevant;
+- whether it appears capable of comparable replay.
+
+Pause with a trace-selection evidence card in guided mode.
+
+**Completion criterion:** exactly one trace ID is selected for a concrete reason.
+Never guess or infer a remote trace ID.
+
+## Phase 2: Preview and import
+
+Run Kitaru's dry-run preview first. Validate:
+
+- exactly the selected trace appears;
+- source attribution is verified or explicitly caller-attributed;
+- no version conflict or rejected outcome exists;
+- graph integrity and fragmentation are disclosed;
+- importer root-input readiness is reported;
+- message-history readiness remains unknown until Phase 3 validates a boundary;
+- the exact destination stack name or ID is present in the preview command;
+- the user understands that raw evidence can contain sensitive data.
+
+Render an import evidence table and explain what will be stored, where it will
+be stored, the stack's reported storage accessibility, and that importing calls
+neither the model nor the agent's tools. Show message-history boundary status as
+HOLD with `adapter validation pending`.
+
+Pause for explicit storage consent. Only then reuse the identical preview
+command and exact `--stack` selector, adding `--write` and
+`--confirm-data-storage`.
+
+Accept a successful created, resumed, or unchanged outcome and capture the
+exact imported execution ID. Inspect it with the normal execution surface.
+
+**Completion criterion:** one immutable imported execution ID exists and the
+case file records the attribution and readiness result. Any conflict stops
+before storage.
+
+## Phase 3: Map the evidence and choose a boundary
+
+Load normalized imported replay evidence. Draw the sanitized imported DAG from
+observation IDs, names, kinds, statuses, and parent relationships.
+
+Enumerate and adapter-validate complete model-message and tool-result boundaries
+using the project-adaptation contract. Render:
+
+1. the imported DAG;
+2. a boundary table with observation, kind, sequence, occurrence, call ID, and
+   validation state;
+3. a boundary diagram separating the immutable prefix from live candidate work;
+4. a tool-safety diagram showing exact-match response service and blocked
+   misses.
+
+Recommend the boundary that preserves the strongest recorded world while
+leaving the candidate a meaningful decision. Explain this in the user's agent:
+
+- which earlier model and tool work becomes fixed evidence;
+- which candidate model calls run again and incur cost;
+- which recorded tool responses can be served;
+- that none of the candidate's live tool callables run during imported replay;
+- that an exact match returns stored evidence and every miss is blocked;
+- what a blocked miss would mean for the verdict.
+
+Pause for boundary selection in guided mode.
+
+If no message-history boundary validates, offer one root-input diagnostic. Mark
+the case HOLD and state that it cannot become a comparable CI gate.
+
+**Completion criterion:** one adapter-validated boundary is selected, or the
+case is explicitly limited to a root-input HOLD.
+
+## Phase 4: Reproduce the recorded path
+
+When the source-compatible implementation is executable, prepare one control
+replay from the selected boundary. Require explicit trial, USD, token, and
+duration limits. Show a paid-execution card naming the exact request and
+idempotency key, then obtain approval before calling the model. If the installed
+API cannot enforce `RegressionLimits`, stop rather than run unbounded.
+
+Validate and display:
+
+| Evidence | Required result |
+|---|---|
+| Comparability | `recorded_path_comparable` |
+| Recorded responses | every eligible response served |
+| Blocked calls | 0 |
+| Path divergences | 0 |
+| Objective | passed |
+| Protections | every expected protection present and passed |
+
+Explain which parts of the original execution were reused and which were
+recomputed. Relate every miss or divergence to the agent's current tool schema
+or behavior.
+
+**Completion criterion:** the control reproduces comparable recorded-path
+evidence. Otherwise HOLD and diagnose boundary or schema drift before testing a
+candidate.
+
+If the historical implementation cannot be executed, state that the missing
+control weakens causal confidence. Ask whether to continue with the candidate as
+a labeled diagnostic rather than silently treating it as equivalent evidence.
+
+## Phase 5: Run the protected candidate
+
+Freeze the selected trace and boundary. Construct an idempotency key from the
+trace, boundary, candidate version, scorer set, protection set, repeats, and
+limits.
+
+Start with one repeat, `on_error="collect"`, and explicit
+`RegressionLimits`. If the installed API cannot enforce the limits, stop rather
+than run unbounded.
+
+Before execution, render:
+
+- the candidate and exact version;
+- the question this comparison answers;
+- objective and threshold;
+- each protection and its forbidden behavior;
+- provider/model calls expected to run;
+- low, base, and high cost estimates, or `unknown`;
+- trial, USD, token, and duration limits;
+- the within-trial overshoot warning.
+
+Pause for authorization of this one exact request and idempotency key.
+
+After execution, render the verdict diagram, protection table, comparability,
+recorded-response hits and misses, blocked calls, divergences, child execution
+IDs, reason codes, and actual usage.
+
+Interpret evidence in this order:
+
+1. any failed protection produces FAIL;
+2. otherwise incomplete comparability produces HOLD;
+3. otherwise an unmet objective produces FAIL;
+4. only comparable evidence with objective and protections passing produces
+   PASS.
+
+Explain what the result means for this agent. For example, distinguish "the
+candidate achieved the requested outcome" from "the candidate attempted a
+forbidden write while doing so."
+
+**Completion criterion:** one persisted candidate experiment has every expected
+objective and protection plus a fully explained PASS, HOLD, or FAIL verdict.
+Stop this candidate path on HOLD or FAIL unless the user authorizes a concrete
+code or evidence correction.
+
+## Phase 6: Widen or rerun the evidence
+
+If more representative traces exist, offer to widen the experiment. Show which
+members have validated comparable boundaries before spending. Root-input-only
+members cannot make the comparable subset pass.
+
+For the gate candidate, prepare a rerun of the exact experiment ID with
+explicit limits and a caller-chosen or deterministically derived idempotency
+key. Show a new paid-execution card and obtain approval for the exact rerun plus
+one identical idempotency check. Then run the request twice with the same key
+and verify:
+
+- the experiment ID is unchanged;
+- no new trial or child execution was submitted;
+- no additional replay spend was incurred.
+
+Render forecast versus actual cost and the final evidence ladder.
+
+**Completion criterion:** the exact bounded rerun is PASS and the idempotency
+check returns the same stored attempt. Otherwise end STOPPED SAFELY.
+
+## Phase 7: Prepare the regression gate
+
+Read the CI reference. Propose deterministic scorer, protection, recorded-tool,
+boundary, and idempotency tests before the paid live gate.
+
+Generate the project-specific CI test only after showing:
+
+- exact target path;
+- exact frozen experiment ID;
+- candidate registration and entrypoint;
+- idempotency strategy;
+- objective and protections;
+- limits;
+- live-provider markers and credential behavior;
+- expected pull-request and scheduled-suite cost.
+
+Run the narrowest available non-live validation. Run the live gate only under a
+separate paid authorization unless it was included in the exact Phase 6
+authorization.
+
+Explain that `assert_pass()` fails the test, while repository branch
+protection must make the containing CI job required before it blocks a merge.
+
+**Completion criterion:** the proposed or approved test targets the exact
+experiment, uses a commit-derived candidate version, explicit limits, a stable
+idempotency key, and `assert_pass()`. Report merge-gate wiring separately.
+
+## Finish
+
+Render the final report defined by the visual-evidence contract.
+
+Use **CI READY** only when import, boundary, control, protected candidate,
+bounded rerun, idempotency, and test-artifact criteria all pass.
+
+Otherwise use **STOPPED SAFELY** with the precise phase, HOLD or FAIL reason,
+preserved evidence IDs, actual spend, and one corrective next action.
+
+Do not automatically make another paid attempt with a fresh key, commit files,
+push changes, or change branch-protection settings.

--- a/skills/kitaru-trace-to-test/agents/openai.yaml
+++ b/skills/kitaru-trace-to-test/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Kitaru Trace to Test"
+  short_description: "Turn a Langfuse trace into a regression gate"
+  default_prompt: "Use $kitaru-trace-to-test to turn a selected Langfuse incident trace into a safe Kitaru replay and bounded CI regression test."
+
+policy:
+  allow_implicit_invocation: false

--- a/skills/kitaru-trace-to-test/references/capabilities.md
+++ b/skills/kitaru-trace-to-test/references/capabilities.md
@@ -1,0 +1,139 @@
+# Capability contract
+
+Read this file during preflight and whenever a command or API assumption is
+uncertain. Verify the installed Kitaru version and local `--help` output before
+using a copied command.
+
+## Shipped workflow
+
+| Capability | Current contract |
+|---|---|
+| JSONL import | Import one or more Langfuse traces from an observations JSONL export. |
+| Remote import | Fetch one known `langfuse://trace/<id>` through Langfuse's observations API. |
+| Preview | Import is dry-run by default. It validates the selection and reports what would be stored. |
+| Storage | Writing requires `--write --confirm-data-storage`. Raw rows can contain sensitive data. |
+| Attribution | Each import declares one registered Agent and one exact AgentVersion. |
+| Imported record | The imported execution is immutable historical evidence. Native checkpoint resume, retry, and cancel are refused. |
+| Imported replay | A registered PydanticAI `KitaruAgent` can replay from root input or a validated message-history boundary. |
+| Recorded tools | A recorded response is served only when tool name and arguments match exactly. A miss is blocked and never calls the original tool callable. |
+| Evaluation | Objectives and agent protections produce a persisted experiment and a PASS, HOLD, or FAIL verdict. |
+| Bounded rerun | `RegressionLimits` can limit trials, reported cost, reported tokens, and duration between trials. |
+| CI assertion | `result.assert_pass()` raises for HOLD and FAIL. |
+| Idempotency | An identical logical request with the same idempotency key returns the stored attempt instead of submitting another trial. |
+
+## Unsupported or narrower than the product story
+
+- Kitaru does not list, search, or rank remote Langfuse traces. It fetches an
+  exact trace ID. Trace discovery must come from the user, a JSONL export, the
+  Langfuse UI, or a host-provided Langfuse/browser integration.
+- Treat imported replay as PydanticAI-only unless the installed Kitaru docs
+  explicitly establish another adapter.
+- Root-input replay is a counterfactual. It does not establish recorded-path
+  comparability.
+- A message-history replay requires a complete adapter-validated model-message
+  or tool-result boundary.
+- There is no generic visual editor for replacing arbitrary imported checkpoint
+  outputs. Do not describe candidate replay as arbitrary checkpoint mutation.
+- Operational limits do not interrupt provider calls already running inside one
+  trial. Tool turns and output retries can make the final trial exceed a cost or
+  token threshold before Kitaru can stop a later trial.
+- Do not promise Langfuse score writeback, derived investigation status,
+  fixture-staleness verification, synthetic case generation, or generic replay
+  across every adapter.
+- Making a test part of a required merge gate is a repository and CI setting,
+  not an effect of `assert_pass()` alone.
+
+## Import commands
+
+For a JSONL preview:
+
+```bash
+kitaru import langfuse <export.jsonl> \
+  --source-project-id <project-id> \
+  --agent <agent-name> \
+  --agent-version <exact-version> \
+  --stack <exact-stack-name-or-id>
+```
+
+For a known remote trace:
+
+```bash
+kitaru import langfuse "langfuse://trace/<trace-id>" \
+  --agent <agent-name> \
+  --agent-version <exact-version> \
+  --stack <exact-stack-name-or-id>
+```
+
+The remote form reads `LANGFUSE_PUBLIC_KEY`,
+`LANGFUSE_SECRET_KEY`, and optionally `LANGFUSE_BASE_URL` or
+`LANGFUSE_HOST`. Never print their values.
+
+Show the exact stack selector and its reported storage accessibility in the
+consent card. Reuse the identical preview command for the write so the
+destination cannot drift.
+
+After the preview and explicit consent, append:
+
+```text
+--write --confirm-data-storage
+```
+
+Accept only a successful `created`, `resumed`, or `unchanged` outcome with
+an exact imported execution ID.
+
+## Imported replay API
+
+Root-input diagnostic:
+
+```python
+result = candidate.replay(
+    imported_execution_id,
+    imported_mode="root_input",
+    on_error="collect",
+    idempotency_key=key,
+    repeats=1,
+    scorers=[objective],
+)
+```
+
+Comparable message-history attempt:
+
+```python
+result = candidate.replay(
+    imported_execution_id,
+    imported_mode="message_history",
+    imported_boundary=boundary,
+    on_error="collect",
+    idempotency_key=key,
+    repeats=1,
+    scorers=[objective],
+)
+```
+
+Build `boundary` from immutable replay evidence using
+`ImportedReplayBoundary` and validate it with
+`prepare_imported_replay_history(...,
+fallback_policy=ImportedReplayFallbackPolicy.BLOCK)`.
+
+Rerun an exact frozen experiment:
+
+```python
+from kitaru import RegressionLimits
+
+rerun = candidate.replay(
+    experiment=experiment_id,
+    idempotency_key=key,
+    repeats=1,
+    scorers=[objective],
+    limits=RegressionLimits(
+        max_trials=1,
+        max_cost_usd=approved_cost,
+        max_incurred_tokens=approved_tokens,
+        max_duration_seconds=approved_seconds,
+    ),
+)
+rerun.assert_pass()
+```
+
+Prefer the exact experiment ID over a suite name once the evidence becomes a
+regression gate.

--- a/skills/kitaru-trace-to-test/references/capabilities.md
+++ b/skills/kitaru-trace-to-test/references/capabilities.md
@@ -50,12 +50,24 @@ For a JSONL preview:
 ```bash
 kitaru import langfuse <export.jsonl> \
   --source-project-id <project-id> \
+  --trace-id <selected-trace-id> \
   --agent <agent-name> \
   --agent-version <exact-version> \
   --stack <exact-stack-name-or-id>
 ```
 
-For a known remote trace:
+For a known remote trace, first require the optional Langfuse integration:
+
+```text
+kitaru[langfuse]
+langfuse>=4.7.0,<5
+```
+
+Verify the installed Kitaru release supports this range and that the optional
+SDK imports successfully before requesting credentials or fetching a trace. If
+not, place the remote path on HOLD and show the installation requirement.
+
+Then preview the known trace:
 
 ```bash
 kitaru import langfuse "langfuse://trace/<trace-id>" \
@@ -67,6 +79,10 @@ kitaru import langfuse "langfuse://trace/<trace-id>" \
 The remote form reads `LANGFUSE_PUBLIC_KEY`,
 `LANGFUSE_SECRET_KEY`, and optionally `LANGFUSE_BASE_URL` or
 `LANGFUSE_HOST`. Never print their values.
+
+For JSONL, require the preview to report exactly one selected trace before
+showing storage consent. Preserve the exact `--trace-id` selector in the write
+command.
 
 Show the exact stack selector and its reported storage accessibility in the
 consent card. Reuse the identical preview command for the write so the

--- a/skills/kitaru-trace-to-test/references/ci-gate.md
+++ b/skills/kitaru-trace-to-test/references/ci-gate.md
@@ -17,6 +17,25 @@ A case is eligible only when:
 A root-input replay, divergent tool path, blocked recorded response, missing
 protection, HOLD, or FAIL is not gate-ready.
 
+## Recurring authorization
+
+Treat a live CI gate as standing authorization for future persistent
+registrations and paid replay requests. Before enabling it, show:
+
+| Authorization fact | Required value |
+|---|---|
+| Triggers | pull request, push, schedule, or manual |
+| Frequency | expected runs per day, week, or month |
+| Registration | one immutable AgentVersion per candidate commit |
+| Credentials | provider and CI secret scope |
+| Spend | maximum per run and estimated recurring total |
+| Retries | job retry behavior and idempotency key reuse |
+| Control | who can disable or change the required job |
+
+Obtain explicit standing authorization for that configuration. Without it, keep
+the live test behind `KITARU_RUN_REPLAY_GATE=1` and leave the CI job disabled or
+manual.
+
 ## Exact experiment pattern
 
 Use the exact experiment ID. Register the current candidate with a
@@ -29,15 +48,25 @@ Adapt this shape to the project rather than copying names:
 import hashlib
 import os
 
+import pytest
+
 from kitaru import RegressionLimits
 
 from my_agent.evals import candidate_agent, quality_objective
 
 
 EXPERIMENT_ID = "<exact-experiment-id>"
+PROVIDER_CREDENTIAL = "<PROVIDER_API_KEY>"
+PROVIDER_MARKER = "<repository-provider-marker>"
+
+pytestmark = [pytest.mark.live_llm, getattr(pytest.mark, PROVIDER_MARKER)]
 
 
 def test_incident_regression_gate() -> None:
+    if os.environ.get("KITARU_RUN_REPLAY_GATE") != "1":
+        pytest.skip("set KITARU_RUN_REPLAY_GATE=1 to authorize paid replay")
+    if not os.environ.get(PROVIDER_CREDENTIAL):
+        pytest.skip(f"{PROVIDER_CREDENTIAL} is not configured")
     candidate_ref = os.environ.get("GITHUB_SHA") or os.environ[
         "KITARU_CANDIDATE_LABEL"
     ]
@@ -62,6 +91,10 @@ def test_incident_regression_gate() -> None:
     )
     result.assert_pass()
 ```
+
+Replace the provider credential and marker placeholders with the repository's
+actual values. Keep the opt-in guard even after standing authorization; enable
+it deliberately in the authorized CI job environment.
 
 In CI, `GITHUB_SHA` supplies the immutable candidate identity. For local
 execution, require an explicit `KITARU_CANDIDATE_LABEL` derived from a commit
@@ -109,6 +142,7 @@ Keep the provider test:
 
 - under the repository's live-test location;
 - marked with the repository's provider and live-spend markers;
+- disabled unless `KITARU_RUN_REPLAY_GATE=1`;
 - skipped cleanly when credentials are absent;
 - limited to one trial on pull requests;
 - configured with a short bounded prompt and explicit operational limits.
@@ -126,6 +160,8 @@ Do not place paid provider calls in deterministic test jobs.
 | Spend | one trial and explicit cost, token, and duration limits |
 | Verdict | `assert_pass()` |
 | Local checks | deterministic tests pass |
+| CI authorization | recurring triggers, credentials, registration, spend, and retries are approved |
+| Opt-in | `KITARU_RUN_REPLAY_GATE=1` is set only in the authorized job |
 | CI wiring | containing job exists and credential behavior is documented |
 | Merge protection | required-job configuration is verified or explicitly outstanding |
 

--- a/skills/kitaru-trace-to-test/references/ci-gate.md
+++ b/skills/kitaru-trace-to-test/references/ci-gate.md
@@ -1,0 +1,147 @@
+# CI regression gate
+
+Read this file only after a candidate experiment has produced useful evidence.
+The gate is the last rung, not a substitute for boundary validation.
+
+## Gate eligibility
+
+A case is eligible only when:
+
+- import produced an exact immutable execution ID;
+- a PydanticAI message-history boundary validated with blocked fallback;
+- evidence is `recorded_path_comparable`;
+- the objective and every expected protection appear in the experiment;
+- the bounded rerun is PASS;
+- repeating the same idempotency request returns the same stored attempt.
+
+A root-input replay, divergent tool path, blocked recorded response, missing
+protection, HOLD, or FAIL is not gate-ready.
+
+## Exact experiment pattern
+
+Use the exact experiment ID. Register the current candidate with a
+commit-derived immutable label. Derive the idempotency key from the candidate
+label and the frozen experiment identity.
+
+Adapt this shape to the project rather than copying names:
+
+```python
+import hashlib
+import os
+
+from kitaru import RegressionLimits
+
+from my_agent.evals import candidate_agent, quality_objective
+
+
+EXPERIMENT_ID = "<exact-experiment-id>"
+
+
+def test_incident_regression_gate() -> None:
+    candidate_ref = os.environ.get("GITHUB_SHA") or os.environ[
+        "KITARU_CANDIDATE_LABEL"
+    ]
+    candidate_label = f"ci-{candidate_ref[:12]}"
+    experiment_key = hashlib.sha256(EXPERIMENT_ID.encode()).hexdigest()[:12]
+    candidate_agent.register(
+        label=candidate_label,
+        entrypoint="my_agent.evals:candidate_agent",
+    )
+
+    result = candidate_agent.replay(
+        experiment=EXPERIMENT_ID,
+        idempotency_key=f"incident-gate-{candidate_label}-{experiment_key}",
+        repeats=1,
+        scorers=[quality_objective],
+        limits=RegressionLimits(
+            max_trials=1,
+            max_cost_usd=<approved-cost>,
+            max_incurred_tokens=<approved-tokens>,
+            max_duration_seconds=<approved-seconds>,
+        ),
+    )
+    result.assert_pass()
+```
+
+In CI, `GITHUB_SHA` supplies the immutable candidate identity. For local
+execution, require an explicit `KITARU_CANDIDATE_LABEL` derived from a commit
+and dirty-tree state. Do not silently reuse a generic `local` label.
+
+Show the exact proposed path and diff before creating or changing a test file.
+
+## Cost implications
+
+Explain the concrete sequence:
+
+1. The test registers the current commit as a candidate version.
+2. Replay calls the candidate model from the frozen boundary.
+3. Exact recorded tool matches return stored responses.
+4. Unmatched tool calls are blocked and recorded.
+5. The objective and protections inspect the resulting child execution.
+6. The user is billed for live model requests made by the replay.
+7. A repeated CI attempt with the same key returns stored evidence instead of
+   making another replay trial.
+
+`max_trials=1` limits replay trials, not provider calls within a trial. A
+single agent trial may include several model turns and output retries.
+
+Use the cheapest comparable shape on pull requests. Put larger repeat counts or
+wider suites in an explicitly scheduled job when the repository's cost policy
+permits it.
+
+## Recommended tests
+
+### Deterministic tests
+
+- the objective convicts a known bad execution and accepts a known good one;
+- each protection convicts its forbidden behavior;
+- each protection accepts a safe behavior;
+- exact recorded tool name and arguments serve the recorded response;
+- changed arguments are blocked;
+- the blocked path never invokes the live tool callable;
+- malformed or incomplete boundaries are rejected;
+- root-input replay remains HOLD rather than being called comparable;
+- the same idempotency request returns the same experiment.
+
+### Live provider gate
+
+Keep the provider test:
+
+- under the repository's live-test location;
+- marked with the repository's provider and live-spend markers;
+- skipped cleanly when credentials are absent;
+- limited to one trial on pull requests;
+- configured with a short bounded prompt and explicit operational limits.
+
+Do not place paid provider calls in deterministic test jobs.
+
+## Validation before claiming CI READY
+
+| Check | Required evidence |
+|---|---|
+| Imports | test module imports without unintended provider calls |
+| Frozen identity | exact experiment ID appears in the test |
+| Candidate identity | commit-derived immutable label |
+| Retry safety | deterministic idempotency key |
+| Spend | one trial and explicit cost, token, and duration limits |
+| Verdict | `assert_pass()` |
+| Local checks | deterministic tests pass |
+| CI wiring | containing job exists and credential behavior is documented |
+| Merge protection | required-job configuration is verified or explicitly outstanding |
+
+A passing local test does not itself block merges. Report CI READY only for the
+test artifact. Report merge-gate activation separately.
+
+## Failure behavior
+
+A CI failure should print or preserve:
+
+- verdict and reason codes;
+- failed objective or protection;
+- comparability;
+- recorded response hits and misses;
+- blocked calls and path divergences;
+- actual cost, tokens, and duration;
+- exact experiment and child execution IDs.
+
+Do not automatically rerun a failed paid gate with a new idempotency key.

--- a/skills/kitaru-trace-to-test/references/project-adaptation.md
+++ b/skills/kitaru-trace-to-test/references/project-adaptation.md
@@ -1,0 +1,138 @@
+# Project adaptation
+
+Read this file during preflight and boundary selection. The checked-in Kitaru
+support demo is a conformance example, not a template whose identifiers should
+be copied.
+
+## Inspect before proposing code
+
+Search the user's repository for:
+
+- `KitaruAgent(...)` construction;
+- `.register(...)` calls and stable module entrypoints;
+- source and candidate variants;
+- `@scorer` declarations;
+- `@agent.protection(...)` declarations;
+- tool names, schemas, and implementations;
+- existing live-provider test markers and spend guards;
+- repository instructions governing tests and CI.
+
+Do not import application modules merely to inspect them if import-time code can
+make provider calls or mutate external state. Prefer source inspection first.
+
+Summarize the result:
+
+| Requirement | Selected value | Evidence | State |
+|---|---|---|---|
+| Source agent | name and entrypoint | file and symbol | READY or HOLD |
+| Source version | exact ID or label | registration or trace | READY or HOLD |
+| Candidate agent | entrypoint | file and symbol | READY or HOLD |
+| Objective | scorer name and threshold | declaration | READY or HOLD |
+| Protections | expected IDs | declarations | READY or HOLD |
+| Tool policy | read, write, unknown | definitions | READY or HOLD |
+
+A completion-only protection does not establish domain safety. Require at least
+one protection for the behavior that must not occur. If the relevant business
+rule is unknown, ask the user rather than inventing it.
+
+## Classify tools
+
+| Classification | Meaning during imported replay |
+|---|---|
+| Read | A recorded exact match may be served. A miss is still blocked under the safe fallback policy. |
+| Write | Never permit a miss to reach the live callable. A candidate attempt can still be recorded as evidence for a protection. |
+| Unknown | Treat as write-capable until the user or code establishes otherwise. |
+
+Explain the consequence in the user's terms. For example:
+
+> `issue_refund` can move money. During this replay, an exact recorded
+> response can be returned to the agent, but a changed call is blocked before
+> the real refund function runs. The blocked attempt still tells us whether the
+> candidate tried the forbidden action.
+
+Never make secrets, prompts, file paths, customer data, or raw tool values part
+of a report.
+
+## Trace selection
+
+Use this order:
+
+1. Use an exact trace ID or trace URL supplied by the user.
+2. For JSONL, preview or parse identities without writing and summarize the
+   available traces.
+3. If the host has an explicit Langfuse integration or browser automation,
+   offer to use it for read-only discovery.
+4. Otherwise direct the user to the Langfuse trace view and ask for the exact
+   trace ID.
+
+Do not guess IDs. Do not claim that Kitaru discovered remote candidates.
+
+Rank candidates using:
+
+| Signal | Prefer | Avoid |
+|---|---|---|
+| State | terminal completed or failed trace | active or partially ingested trace |
+| Failure | clear user-visible problem | vague dissatisfaction with no evidence |
+| Tools | complete results and stable schemas | missing results or opaque side effects |
+| Version | verified source version | conflicting source fields |
+| Decision room | meaningful choice remains after a boundary | trace already effectively finished |
+| Representativeness | recurring production path | one-off anomaly unless incident-specific |
+
+A root-input-only trace can support a diagnostic counterfactual. It cannot by
+itself support a comparable CI gate.
+
+## Enumerate and validate boundaries
+
+Load the immutable bundle with
+`load_imported_replay_evidence(execution_id)`.
+
+For each observation, group replay parts by `message_index`:
+
+- a group containing only model text and tool calls is a model-message
+  candidate;
+- a group containing only tool results is a tool-result candidate;
+- mixed or incomplete groups are not candidates.
+
+For every candidate, construct an `ImportedReplayBoundary` from its
+observation ID, sequence, occurrence, and tool call ID when required. Validate
+it with:
+
+```python
+prepare_imported_replay_history(
+    evidence,
+    boundary=boundary,
+    fallback_policy=ImportedReplayFallbackPolicy.BLOCK,
+)
+```
+
+Catch `ImportedReplayPreparationError` and show the rejection reason. Never
+silently downgrade a rejected boundary to root input.
+
+Prefer the latest valid tool-result boundary that:
+
+- preserves a meaningful decision for the candidate;
+- keeps the relevant recorded responses available;
+- uses tool names and schemas compatible with the candidate;
+- does not start after the behavior being tested.
+
+If a model-message boundary is stronger for the actual question, explain why
+before selecting it.
+
+## Adaptation changes
+
+If required code is missing, propose the smallest coherent change:
+
+- a stable registered candidate entrypoint;
+- one objective tied to the intended outcome;
+- one or more domain protections tied to forbidden behavior;
+- a narrow replay helper or test.
+
+Show the exact files and intended behavior before editing. Keep application
+logic out of the skill repository. Do not copy the support demo's agent names,
+versions, tool names, prompts, scorer, or protection IDs.
+
+## Preflight completion
+
+Preflight completes only when every required item is either READY or explicitly
+accepted as a diagnostic-only HOLD. Paid replay cannot start while a relevant
+tool remains unknown or while no domain protection exists.

--- a/skills/kitaru-trace-to-test/references/project-adaptation.md
+++ b/skills/kitaru-trace-to-test/references/project-adaptation.md
@@ -50,8 +50,9 @@ Explain the consequence in the user's terms. For example:
 > the real refund function runs. The blocked attempt still tells us whether the
 > candidate tried the forbidden action.
 
-Never make secrets, prompts, file paths, customer data, or raw tool values part
-of a report.
+Permit approved project-relative source and test paths when they identify the
+code under review. Keep absolute user paths, trace-derived paths, secrets,
+prompts, customer data, and raw tool values out of reports.
 
 ## Trace selection
 

--- a/skills/kitaru-trace-to-test/references/visual-evidence.md
+++ b/skills/kitaru-trace-to-test/references/visual-evidence.md
@@ -86,10 +86,10 @@ Ask one precise question:
 
 Do not ask "Continue?" or combine unrelated approvals.
 
-In reduced/demo mode, combine several read-only findings into one pause card,
-but keep storage, paid execution, and file edits as separate authorized actions
-unless one paid-execution card states the exact trace, candidate, limits, and
-expected spend.
+In reduced/demo mode, combine several read-only findings into one pause card.
+Always keep storage, paid execution, and file edits as separate authorized
+actions. A paid-execution card authorizes only the exact trace, candidate,
+limits, and expected spend it states.
 
 ## Required visual outputs
 

--- a/skills/kitaru-trace-to-test/references/visual-evidence.md
+++ b/skills/kitaru-trace-to-test/references/visual-evidence.md
@@ -1,0 +1,264 @@
+# Visual evidence and pause contract
+
+Read this file before the first user-facing update. Apply it to every phase,
+including failure paths. The user should be able to understand the investigation
+by scanning headings, status symbols, diagrams, and short implications.
+
+## Evidence ladder
+
+Use the same three states everywhere:
+
+| State | Meaning | Consequence |
+|---|---|---|
+| ✅ PASS | Evidence supports the next claim | Continue to the next rung |
+| ⏸ HOLD | Evidence is incomplete or not comparable | Diagnose or narrow the claim |
+| ❌ FAIL | Evidence shows forbidden or unsuccessful behavior | Stop this candidate path |
+
+Do not use PASS to mean that a command merely exited zero. Name the claim that
+passed, such as source attribution, recorded-path comparability, or a protection.
+
+The portable ladder is:
+
+```text
+Trace selected → Import verified → Boundary validated → Control reproduced
+               → Candidate protected → Bounded rerun passed → CI gate ready
+```
+
+Use Mermaid as a supplemental view only when the host is known to render it.
+
+Never visually connect two rungs until the earlier rung's completion criterion
+has been checked.
+
+## Pause card
+
+At every pause, use this exact order:
+
+### 1. Outcome heading
+
+```text
+## ⏸ Import preview ready
+```
+
+Use one status symbol and name the claim being evaluated.
+
+### 2. Evidence table
+
+Show only facts relevant to the decision:
+
+| Check | Observed | State |
+|---|---|---|
+| Trace selection | one exact trace | ✅ |
+| Source attribution | caller-attributed | ⏸ |
+| Importer readiness | root input ready | ✅ |
+| Message-history boundary | adapter validation pending | ⏸ |
+| Destination | local isolated stack | ✅ |
+
+### 3. Agent implication
+
+Write two to four direct sentences explaining the mechanism in the user's
+agent. Name the agent, candidate, tools, and behavior where known.
+
+Example:
+
+> This trace contains the complete result of your
+> `lookup_account` call, so Kitaru can return that recorded result without
+> calling the service. Your `issue_refund` tool can move money. A changed
+> refund call will therefore be blocked before its real Python callable runs.
+> The blocked attempt still becomes evidence about what the candidate tried.
+
+Avoid generic statements such as "this is safe" without naming what cannot run.
+
+### 4. What the next action changes
+
+Distinguish state changes from read-only actions:
+
+| Next action | Writes data? | Calls a model? | Can call live tools? | Expected cost |
+|---|---:|---:|---:|---:|
+| Import selected trace | yes | no | no | $0 |
+| Candidate replay | yes | yes | no live tool callables run | estimate or unknown |
+
+### 5. Decision
+
+Ask one precise question:
+
+> Store this trace in the displayed Kitaru stack and record its immutable
+> execution ID?
+
+Do not ask "Continue?" or combine unrelated approvals.
+
+In reduced/demo mode, combine several read-only findings into one pause card,
+but keep storage, paid execution, and file edits as separate authorized actions
+unless one paid-execution card states the exact trace, candidate, limits, and
+expected spend.
+
+## Required visual outputs
+
+Use compact text or Unicode diagrams as the portable default. Add Mermaid when
+the host is known to render it. Evidence tables and the agent implication remain
+mandatory in either form.
+
+### Candidate table
+
+When choosing among traces:
+
+| Trace | Failure signal | Tool evidence | Cost | Readiness | Recommendation |
+|---|---|---|---:|---|---|
+
+State why the preferred trace teaches something about this agent. If remote
+discovery is unavailable, show one row explaining that an exact ID is required
+and give the user the selection criteria.
+
+### Imported DAG
+
+Render observation topology without payload values. Start with a portable view:
+
+```text
+Root · agent · completed
+  └─ Model message · generation
+       └─ lookup_account · tool · completed
+            └─ Model message · generation
+```
+
+When Mermaid renders, add:
+
+```mermaid
+flowchart TD
+    O1["Root · agent · completed"]
+    O2["Model message · generation"]
+    O3["lookup_account · tool · completed"]
+    O4["Model message · generation"]
+    O1 --> O2 --> O3 --> O4
+```
+
+Use short sanitized labels. Preserve parent relationships. If the graph is
+fragmented, show disconnected components and explain how that weakens replay
+evidence.
+
+### Boundary diagram
+
+Show what remains recorded and what runs again:
+
+```text
+[immutable request → recorded model → recorded tool result]
+                              │ selected boundary
+                              ▼
+                    [candidate model runs live]
+                              │
+               exact match ───┴─── miss
+                    ▼                  ▼
+          [stored response]   [blocked + recorded]
+```
+
+When Mermaid renders, add:
+
+```mermaid
+flowchart LR
+    subgraph R["Immutable recorded prefix"]
+        A["User request"] --> B["Model call"] --> C["Recorded tool result"]
+    end
+    C --> D{{"Selected boundary"}}
+    D --> E["Candidate model runs live"]
+    E --> F{"Tool name + args exact match?"}
+    F -- Yes --> G["Serve recorded response"]
+    F -- No --> H["Block call and record attempt"]
+```
+
+Below it, state exactly which model calls incur cost. State that imported
+replay invokes none of the candidate's live tool callables: an exact match
+returns a stored response, and every miss is blocked and recorded.
+
+### Protection view
+
+| Protection | Forbidden behavior | Evidence inspected | Result |
+|---|---|---|---|
+| `<id>` | project-specific behavior | candidate checkpoints | PASS or FAIL |
+
+Do not show "all passed" alone. Connect every protection to its business
+meaning for this agent.
+
+### Verdict view
+
+```text
+protection failed? ─ yes ─→ ❌ FAIL
+        │ no
+        ▼
+recorded-path comparable? ─ no ─→ ⏸ HOLD
+        │ yes
+        ▼
+objective passed? ─ no ─→ ❌ FAIL
+        │ yes
+        ▼
+      ✅ PASS
+```
+
+When Mermaid renders, add:
+
+```mermaid
+flowchart TD
+    A["Candidate attempt"] --> B{"Any protection failed?"}
+    B -- Yes --> F["❌ FAIL"]
+    B -- No --> C{"Recorded-path comparable?"}
+    C -- No --> H["⏸ HOLD"]
+    C -- Yes --> D{"Objective threshold met?"}
+    D -- No --> F
+    D -- Yes --> P["✅ PASS"]
+```
+
+Explain that a passed objective cannot override a failed protection.
+
+### Cost view
+
+| Cost fact | Value | Consequence |
+|---|---:|---|
+| Historical trace | actual, estimated, or unknown | baseline only |
+| Expected candidate range | low to high, or unknown | authorization estimate |
+| Trial limit | approved value | stops later trials |
+| Actual incurred | result value | billable evidence |
+| Idempotency check | same or new attempt | confirms retry cost behavior |
+
+Never invent prices. Use imported actual cost, Kitaru's labeled estimate, an
+authoritative current price source available to the host, or "unknown". Make the
+within-trial overshoot warning visible next to the limit.
+
+## Final report
+
+Keep the live conversation as the primary report. Offer a sanitized Markdown
+artifact only with approval. Default temporary state should contain identifiers
+and verdict facts, not evidence payloads.
+
+The final report must contain:
+
+1. the evidence ladder with the reached rung;
+2. the adaptation table;
+3. trace selection and attribution;
+4. imported DAG;
+5. selected boundary and its implication;
+6. tool-safety and protection views;
+7. control, candidate, and bounded-rerun results;
+8. forecast and actual cost;
+9. exact imported execution and experiment IDs;
+10. recommended tests and CI status;
+11. either `CI READY` or `STOPPED SAFELY`.
+
+## Terminal cards
+
+### CI READY
+
+Use only when every required rung passed. State that repository CI must still
+make the job required before it blocks merges.
+
+### STOPPED SAFELY
+
+Show:
+
+| Field | Value |
+|---|---|
+| Stopped at | phase and rung |
+| Verdict | HOLD or FAIL |
+| Why | concrete missing or adverse evidence |
+| Preserved IDs | execution and experiment IDs |
+| Spend | actual incurred amount or unknown |
+| Next action | one corrective step |
+
+Stopping safely is a successful outcome of the workflow. Do not keep spending
+until a candidate happens to pass.


### PR DESCRIPTION
## Summary

- add the user-invoked `kitaru-trace-to-test` skill
- guide one selected Langfuse trace through previewed import, validated PydanticAI replay, protected candidate evidence, bounded rerun, and a proposed CI gate
- make pause points visual and decision-specific with evidence tables, portable diagrams, agent implications, safety effects, and cost exposure
- split shipped capabilities, project adaptation, visual reporting, and CI guidance into progressive references
- update the nine-skill inventory and bump Claude plugin metadata to `0.8.0`

## Why

The replay-fork example demonstrates a strong incident-to-regression story, but its support-agent names and helper commands are application-specific. This skill turns that story into a portable workflow while keeping the current product boundary explicit, especially exact trace discovery, PydanticAI-only imported replay, blocked tool misses, PASS/HOLD/FAIL semantics, and within-trial cost overshoot.

## Key decisions

- keep the skill user-invoked because it can register agent versions, store trace evidence, make paid model calls, and propose CI changes
- use an evidence ladder with only two terminal outcomes: `CI READY` or `STOPPED SAFELY`
- require a structured pause card before every persistent or paid action
- use text and Unicode diagrams as the portable default, with Mermaid only when the host renders it
- require exact stack selection, explicit replay limits, recorded-path comparability, domain protections, and idempotency verification before calling a case gate-ready

## Reviewer Notes

The main behavior lives in `skills/kitaru-trace-to-test/SKILL.md`. Follow its phases as a case file that accumulates evidence rather than as a generic tutorial. The highest-risk area is the transition from imported evidence to a paid candidate replay: the skill must explain which model work runs again, state that no live tool callable runs during imported replay, and stop on missing boundaries, tool-policy ambiguity, HOLD, or FAIL.

The visual contract in `references/visual-evidence.md` defines every pause shown to a user. Please check that each pause names the evidence, explains the consequence for the actual agent, distinguishes reads from writes and paid calls, and asks one precise authorization question.

`disable-model-invocation: true` and `agents/openai.yaml` both make this consequential workflow explicit-only. The generic Codex skill validator currently rejects the Claude-specific frontmatter extension, so frontmatter and policy were validated directly instead.

### Reproduction

1. Install this branch as a local Claude Code plugin or copy `skills/kitaru-trace-to-test` into a test host skill directory.
2. Invoke `/kitaru-trace-to-test` in a PydanticAI agent repository with a Langfuse trace ID or observations JSONL export.
3. Confirm the first response displays the selected guided or demo mode and a portable evidence ladder.
4. At import preview, confirm message-history readiness remains `HOLD` until adapter boundary validation and that the exact destination stack is shown.
5. At a replay pause, confirm the card names the candidate, objective, protections, limits, expected spend, and states: exact match returns a recorded response; every miss is blocked; no live tool callable runs.
6. Confirm a root-input-only trace or failed protection ends `STOPPED SAFELY` instead of being promoted to a CI gate.

Local checks run:

- parsed skill and UI YAML, including explicit-only invocation policy
- checked balanced Markdown fences and the under-500-line `SKILL.md`
- validated both plugin JSON files with `jq`
- ran `git diff --check`
- searched for stale eight-skill inventory text, TODOs, and support-demo identifiers
