### PR TITLE
Align skills with Kitaru develop

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "Build Kitaru integrations, investigate sessions, select evaluators, and run bounded replay experiments",
-    "version": "0.10.1",
+    "version": "0.10.2",
     "homepage": "https://kitaru.ai",
     "repository": "https://github.com/zenml-io/kitaru-skills"
   },
@@ -16,7 +16,7 @@
       "name": "kitaru",
       "source": "./",
       "description": "Claude Code package for Kitaru integrations, human-reviewed investigations, evaluator selection and authoring, and safe bounded replay experiments.",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "author": {
         "name": "ZenML",
         "url": "https://kitaru.ai"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "kitaru",
   "description": "Build Kitaru integrations, investigate sessions, select evaluators, and run bounded replay experiments",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": {
     "name": "ZenML",
     "url": "https://kitaru.ai"

--- a/README.md
+++ b/README.md
@@ -45,11 +45,19 @@ operations in the meantime.
 ## Requirements
 
 These skills track the Kitaru 0.22 CLI, MCP, SDK, and adapter contracts developed
-on [`kitaru/develop`](https://github.com/zenml-io/kitaru/tree/develop). Until a
-stable 0.22 release is available, install a 0.22 release candidate explicitly;
-an ordinary stable-only installation may still resolve to Kitaru 0.21. Each
-skill verifies the installed version and public schema before it acts, and stops
-when the required contract is unavailable.
+on [`kitaru/develop`](https://github.com/zenml-io/kitaru/tree/develop). The
+currently verified Python range is `kitaru>=0.22.0rc4,<0.23`. Until a stable
+0.22 release is available, enable prereleases explicitly:
+
+```bash
+uv add --prerelease allow "kitaru[cli,mcp]>=0.22.0rc4,<0.23"
+```
+
+This range accepts later 0.22 release candidates and the stable 0.22 release,
+but not an unverified 0.23 release. An ordinary stable-only installation may
+still resolve to Kitaru 0.21. Each skill verifies the installed version and
+public schema before it acts, and stops when the required contract is
+unavailable.
 
 When the Kitaru product provides a skill handoff from frontend onboarding, the
 investigation skill continues from that context. It drives the journey according

--- a/README.md
+++ b/README.md
@@ -44,16 +44,23 @@ operations in the meantime.
 
 ## Requirements
 
-Kitaru's light frontend onboarding directs users into the investigation skill.
-It then drives the journey according to one simple choice: start from a session
-the user wants to understand, or explore a bounded session population for
-recurring problems and unexpectedly good behavior. If an unsupported provider
-prevents sessions from entering Kitaru, the importer-builder skill creates and
-validates the missing integration, then hands usable sessions back to the
-investigation flow. If the application needs in-process recording or replay and
-no supported framework integration exists, the adapter-builder skill verifies
-the installed SDK and public framework hooks before building a project-local
-adapter.
+These skills track the Kitaru 0.22 CLI, MCP, SDK, and adapter contracts developed
+on [`kitaru/develop`](https://github.com/zenml-io/kitaru/tree/develop). Until a
+stable 0.22 release is available, install a 0.22 release candidate explicitly;
+an ordinary stable-only installation may still resolve to Kitaru 0.21. Each
+skill verifies the installed version and public schema before it acts, and stops
+when the required contract is unavailable.
+
+When the Kitaru product provides a skill handoff from frontend onboarding, the
+investigation skill continues from that context. It drives the journey according
+to one simple choice: start from a session the user wants to understand, or
+explore a bounded session population for recurring problems and unexpectedly
+good behavior. If an unsupported provider prevents sessions from entering
+Kitaru, the importer-builder skill creates and validates the missing integration,
+then hands usable sessions back to the investigation flow. If the application
+needs in-process recording or replay and no supported framework integration
+exists, the adapter-builder skill verifies the installed SDK and public framework
+hooks before building a project-local adapter.
 
 After investigation accepts a behavior and cohort, it checks the installed
 evaluator catalog before proposing custom evaluator code. If the user wants to

--- a/skills/kitaru-adapter-builder/references/python-adapters.md
+++ b/skills/kitaru-adapter-builder/references/python-adapters.md
@@ -24,10 +24,10 @@ Python, Kitaru, the framework, the model-provider package, and the test runner.
 Resolve imports and signatures from the installed package rather than assuming
 the latest source tree. First identify which public recording boundary the
 installed package exposes. Do not infer the API from the version string alone:
-the checked Kitaru 0.22 release-candidate source does not export the historical
-`flow`, `checkpoint`, or `log` decorators. A separately built artifact with the
-same version string may expose different symbols, so record its exact source or
-revision before relying on it.
+the checked Kitaru source identifies as `0.22.0rc4` and does not export the
+historical `flow`, `checkpoint`, or `log` decorators. A separately built artifact
+with the same version string may expose different symbols, so record its exact
+source or revision before relying on it.
 
 Only when using the session-node path, verify whether the installed package
 exposes:

--- a/skills/kitaru-adapter-builder/references/python-adapters.md
+++ b/skills/kitaru-adapter-builder/references/python-adapters.md
@@ -24,10 +24,10 @@ Python, Kitaru, the framework, the model-provider package, and the test runner.
 Resolve imports and signatures from the installed package rather than assuming
 the latest source tree. First identify which public recording boundary the
 installed package exposes. Do not infer the API from the version string alone:
-the current Kitaru source identifies as 0.21.0 but does not export the historical
-`flow`, `checkpoint`, or `log` decorators. A separately built holdout artifact
-with the same version string may expose different symbols, so record its exact
-source or revision before relying on it.
+the checked Kitaru 0.22 release-candidate source does not export the historical
+`flow`, `checkpoint`, or `log` decorators. A separately built artifact with the
+same version string may expose different symbols, so record its exact source or
+revision before relying on it.
 
 Only when using the session-node path, verify whether the installed package
 exposes:
@@ -56,22 +56,22 @@ package confirms it. Never copy tokens into code, fixtures, logs, or reports.
 
 ## Use the current reference carefully
 
-The checked `v2-spec-consolidated` source at commit
-`16de433f164a1f9fce0bee87196c36d2dd661b6e` contains independently versioned
-adapter distributions:
+The checked `develop` source at commit
+`3675d90e02a690f2bd9a3ff43eba576f0a813515` contains independently versioned
+adapter distributions. These exact release candidates are published to PyPI:
 
 | Framework | Distribution | Checked source | Advertised capability |
 |---|---|---|---|
-| PydanticAI | `kitaru-pydantic-ai` 0.1.0 | `plugins/packages/pydantic-ai/` | Recording and replay |
-| LangGraph, LangChain, and Deep Agents | `kitaru-langgraph` 0.1.0 | `plugins/packages/langgraph/` | Recording and replay |
-| OpenAI Agents SDK | `kitaru-openai-agents` 0.1.0 | `plugins/packages/openai-agents/` | Recording |
+| PydanticAI | `kitaru-pydantic-ai` 0.1.0rc0 | `plugins/packages/pydantic-ai/` | Recording and replay |
+| LangGraph, LangChain, and Deep Agents | `kitaru-langgraph` 0.1.0rc0 | `plugins/packages/langgraph/` | Recording and replay |
+| OpenAI Agents SDK | `kitaru-openai-agents` 0.1.0rc0 | `plugins/packages/openai-agents/` | Recording and restricted replay |
 
 Their tests live under `plugins/tests/adapters/pydantic_ai/`,
 `plugins/tests/adapters/langgraph/`, and
 `plugins/tests/adapters/openai_agents/`. Adapter distributions are installed by
 agent projects rather than bundled into the core Kitaru wheel. This inventory
-describes the checked source tree, not what is installed in the user's project
-or proof that a registry currently serves the package.
+describes the checked source tree and registry state, not what is installed in
+the user's project.
 
 Check the project's installed distributions and current Kitaru documentation
 before designing a custom adapter. When one of these packages supports the
@@ -125,8 +125,9 @@ Offer one of these outcomes:
 3. stop with the exact async or sync contract that is missing.
 
 Do not infer that an exported sync client or decorator is suitable merely from
-its name. Inspect its installed signature and behavior, then limit the adapter
-and report to the operations that public contract actually supports.
+its name or from an older `0.21.0` installation. Inspect its installed signature
+and behavior, then limit the adapter and report to the operations that public
+contract actually supports.
 
 ## Map one invocation to Kitaru
 

--- a/skills/kitaru-adapter-builder/references/typescript-adapters.md
+++ b/skills/kitaru-adapter-builder/references/typescript-adapters.md
@@ -7,7 +7,7 @@ the installed package proves that they are available.
 ## Contents
 
 - [Establish the installed package surface](#establish-the-installed-package-surface)
-- [Use the feature-branch reference carefully](#use-the-feature-branch-reference-carefully)
+- [Use the current source reference carefully](#use-the-current-source-reference-carefully)
 - [Choose the supported implementation path](#choose-the-supported-implementation-path)
 - [Preserve the framework type surface](#preserve-the-framework-type-surface)
 - [Use the adapter primitives when available](#use-the-adapter-primitives-when-available)
@@ -37,7 +37,7 @@ Verify the installed signatures and request types. Do not write direct REST
 calls when a method is absent.
 
 Then test whether the project can resolve `@zenml-io/kitaru/adapter` and inspect
-its actual exports. The pinned feature-branch snapshot exports `RunRecorder`,
+its actual exports. The checked source snapshot exports `RunRecorder`,
 per-run state, normalized step helpers, replay parsing and resolution, and
 tool-policy helpers. Use only the exports present in the installed or explicitly
 approved local package.
@@ -47,17 +47,21 @@ propose an exact published dependency only when installed metadata or an
 approved registry check proves that it exists, then ask before changing the
 project. Otherwise report publication as unverified and stop.
 
-## Use the feature-branch reference carefully
+## Use the current source reference carefully
 
-The available TypeScript reference is a pre-merge snapshot from:
+The checked TypeScript reference is merged into Kitaru's `develop` branch:
 
 ```text
-branch: origin/feat/ts-support
-commit: 3e7c6d9820778596ca76b1766e6de220c3766a50
-core SDK: packages/core/ (@zenml-io/kitaru@0.1.0-rc.1)
-Mastra adapter: packages/mastra/ (@zenml-io/kitaru-mastra@0.1.0-rc.1)
-Vercel AI adapter: packages/vercel-ai/ (@zenml-io/kitaru-vercel-ai@0.1.0-rc.1)
+branch: origin/develop
+commit: 3675d90e02a690f2bd9a3ff43eba576f0a813515
+core SDK: packages/core/ (@zenml-io/kitaru@0.1.0-rc.2)
+Mastra adapter: packages/mastra/ (@zenml-io/kitaru-mastra@0.1.0-rc.2)
+Vercel AI adapter: packages/vercel-ai/ (@zenml-io/kitaru-vercel-ai@0.1.0-rc.2)
 ```
+
+Those exact release-candidate versions are published to npm. Still inspect the
+project's installed package and lockfile before relying on them because the
+project may pin another version.
 
 All three packages are ESM-only and require Node `>=22.22.0 <23`. The core
 package exports its public client and types plus `./client`, `./environment`,
@@ -80,17 +84,14 @@ adapters require a replay model replacement to appear in the configured
 `allowedReplayModels` list. An unchanged requested model is not checked against
 that list.
 
-The pinned core client is generated from that commit's OpenAPI schema and its
+The checked core client is generated from that commit's OpenAPI schema and its
 recorder no longer sends the removed session `expected` field. This establishes
-compatibility with that pinned repository revision only. The branch contains a
-tag-triggered release workflow and describes the packages as pre-1.0 release
-candidates, but the pinned commit is untagged and publication of these exact
-artifacts is not established. Confirm the installed package exports, published
-version, and compatible server schema before using it.
+compatibility with that checked repository revision only. Confirm the installed
+package exports, version, and compatible server schema before using it.
 
-If the branch or pinned commit cannot be resolved, treat these lessons as
+If the branch or checked commit cannot be resolved, treat these lessons as
 unverified. Rely on the installed package's public types and symbols, and report
-that the branch reference was unavailable.
+that the source reference was unavailable.
 
 Do not copy package source into the user's project. Do not add an unpublished
 workspace dependency without approval. When the user wants to test the branch,
@@ -141,7 +142,7 @@ framework default.
 
 ## Use the adapter primitives when available
 
-At the pinned feature-branch revision, `RunRecorder` demonstrates this lifecycle:
+At the checked `develop` revision, `RunRecorder` demonstrates this lifecycle:
 
 1. `create(...)` creates an in-progress session and isolated `RunState`.
 2. `initialize()` upserts the in-progress root at index `0`.
@@ -154,7 +155,7 @@ At the pinned feature-branch revision, `RunRecorder` demonstrates this lifecycle
    failed.
 
 Verify the installed implementation and the framework callback lifecycle before
-reusing it. The pinned `RunState` does not itself seal `enqueueStep()` when
+reusing it. The checked `RunState` does not itself seal `enqueueStep()` when
 failure finalization begins. The adapter must therefore prove that the framework
 cannot deliver another recording callback after `fail()` starts, or add a local
 closed-state guard. Failure finalization must prevent new writes from entering
@@ -163,7 +164,7 @@ rejection as secondary evidence without letting it replace the primary
 application error. Only then write the failed root and failed session.
 
 Use the installed implementation when it satisfies these invariants rather than
-duplicating it. Verify whether it closes or owns any client resource; the draft
+duplicating it. Verify whether it closes or owns any client resource; the current
 TypeScript client uses `fetch` and does not mirror Python client ownership.
 
 When implementing against the public client without these primitives, reproduce
@@ -191,7 +192,7 @@ For model steps, normalize:
 For tools, wrap only public local tool execution paths. Preserve tool schemas,
 validation, context, abort signals, return types, and public failures.
 
-Use the draft adapters as contrasting lessons:
+Use the current adapters as contrasting lessons:
 
 ### Mastra lessons
 
@@ -220,7 +221,7 @@ unless their public hooks expose a pre-execution decision and terminal result.
 ## Control replay and side effects
 
 Resolve replay identity and overrides through the installed SDK. Do not assume
-the Python environment contract. At the draft revision, the TypeScript SDK
+the Python environment contract. At the checked revision, the TypeScript SDK
 parses `KITARU_REPLAY_ID`, optional task input, and replay overrides through its
 own helpers; verify current precedence and supported fields.
 

--- a/skills/kitaru-importer-builder/references/importer-contract.md
+++ b/skills/kitaru-importer-builder/references/importer-contract.md
@@ -14,7 +14,7 @@ Use this reference to inspect the installed importer surface, implement the pars
 
 ## Authority and capability fingerprint
 
-Treat the installed Kitaru version and offline schema as authoritative. This reference design was checked against Kitaru commit `16de433f164a1f9fce0bee87196c36d2dd661b6e` on `v2-spec-consolidated`; re-check the current installed schema before relying on it.
+Treat the installed Kitaru version and offline schema as authoritative. This reference design was checked against Kitaru commit `3675d90e02a690f2bd9a3ff43eba576f0a813515` on `develop`; re-check the current installed schema before relying on it.
 
 Inspect read-only before emitting exact commands:
 

--- a/skills/kitaru-replay-experiment/references/experiment-contract.md
+++ b/skills/kitaru-replay-experiment/references/experiment-contract.md
@@ -32,7 +32,7 @@ kitaru experiment run watch RUN_UUID
 kitaru experiment run cancel RUN_UUID
 ```
 
-Use JSON objects for `--override`, `--tool-policy`, and `--evaluator-params`. Verify `kitaru commands describe` or installed help before relying on example syntax. Creating an experiment and starting a run are non-idempotent remote writes. Watching is read-only. Cancellation requests settlement but does not wait. Deleting a run immediately removes its replay jobs and tasks and is not a cancellation mechanism.
+Use JSON objects for `--override`, `--tool-policy`, and `--evaluator-params`. Verify `kitaru schema` or installed help before relying on example syntax. Creating an experiment and starting a run are non-idempotent remote writes. Watching is read-only. Cancellation requests settlement but does not wait. Deleting a run immediately removes its replay jobs and tasks and is not a cancellation mechanism.
 
 An experiment requires at least one exact evaluator selection. An omitted evaluator version resolves to latest in the API model, but this skill always pins a version. Configuration can be updated only before the experiment has runs; use a new experiment for a changed condition afterward.
 


### PR DESCRIPTION
## Summary

The public skills now match the active Kitaru 0.22 contract on `kitaru/develop` instead of describing older feature branches and 0.21-era packages.

- Refresh the Python and TypeScript adapter inventories to the published release candidates.
- Document the 0.22 compatibility boundary and make the frontend onboarding handoff conditional on product availability.
- Correct the offline command reference to `kitaru schema` and refresh the importer source snapshot.
- Bump the plugin and marketplace package version to `0.10.2`.

## Validation

- All four skills pass `quick_validate.py`.
- Both plugin JSON files parse, and all three distribution version fields equal `0.10.2`.
- `git diff --check` passes.
- PyPI and npm registry checks confirm the documented Python and TypeScript adapter release candidates.
- Correctness, repository-standards, and agent-native review completed. The one stale draft-label finding was fixed and independently validated.

## Reviewer Notes

Please focus on whether the release inventory and compatibility wording accurately describe the current `kitaru/develop` contract without weakening the installed-version-first safety checks.

### Reproduction

1. Compare the pinned Kitaru source revision and package versions with `kitaru/develop` at `3675d90e02a690f2bd9a3ff43eba576f0a813515`.
2. Run `quick_validate.py` against each directory under `skills/`.
3. Parse `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, then confirm every plugin version is `0.10.2`.
4. Run `git diff --check`.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required because this changes agent instructions and plugin metadata only. After merge, a Kitaru skills maintainer should confirm that the marketplace reports version `0.10.2` and that a fresh installation exposes the updated references. Roll back the merge if the package metadata diverges or installation validation fails.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
