### PR TITLE
Improve investigation review handoff

### DIFF
--- a/skills/kitaru-investigation/SKILL.md
+++ b/skills/kitaru-investigation/SKILL.md
@@ -38,6 +38,7 @@ Infer the starting point before asking a question:
 | What the user has | Start here |
 |---|---|
 | Agent code but no Kitaru sessions | Help the user record the agent or import existing traces through the smallest verified Kitaru path, then continue without restarting intake. |
+| One session and a wish to learn or test the review flow | Run a one-session annotation smoke test. Keep it separate from behavior discovery and make no recurrence, prevalence, cohort, or evaluator claim. |
 | Kitaru sessions but no suspected problem | Use cold-start discovery. |
 | One concerning or surprising session | Use trace-first investigation. |
 | An existing investigation ID | Resume it without repeating intake. |
@@ -60,11 +61,12 @@ Do not preview the entire workflow when only the next step matters. Explain the 
 
 Begin with read-only inspection.
 
-1. Resolve the registered agent and its exact version when possible.
-2. Confirm that relevant sessions exist and identify their agent versions.
-3. Look for an investigation identifier in the request, recent structured output, or Kitaru state. Do not infer identity from a non-unique name when an exact ID is available.
-4. Re-read any matching investigation, its ordered sessions, and its annotations before deciding what comes next.
-5. If registration or import is incomplete, orient the user and help them complete the smallest verified setup step needed to produce relevant sessions. Ask whether they need to record the current agent or import existing traces only when the answer is not apparent. Then continue without restarting intake.
+1. Verify access through the Kitaru CLI or MCP connection already configured in the user's environment. If it is unavailable, follow the project's current setup instructions; never infer an installation command from the repository layout.
+2. Resolve the registered agent and its exact version when possible.
+3. Confirm that relevant sessions exist and identify their agent versions.
+4. Look for an investigation identifier in the request, recent structured output, or Kitaru state. Do not infer identity from a non-unique name when an exact ID is available.
+5. Re-read any matching investigation, its ordered sessions, and its annotations before deciding what comes next.
+6. If registration or import is incomplete, orient the user and help them complete the smallest verified setup step needed to produce relevant sessions. Ask whether they need to record the current agent or import existing traces only when the answer is not apparent. Then continue without restarting intake.
 
 Route from state rather than asking the user to choose an internal stage:
 
@@ -149,8 +151,10 @@ Use this path when the user supplies or identifies a seed session.
 
 1. Resolve the exact seed session and read its complete nodes and payloads.
 2. Ask for the suspected behavior in ordinary language if it is not already clear.
-3. Select a small worklist containing the seed, plausible related sessions, and at least one deliberately dissimilar counterexample.
+3. When comparable sessions exist, select a small worklist containing the seed, plausible related sessions, and at least one deliberately dissimilar counterexample.
 4. Treat the suspicion as a search direction, not a label.
+
+When only one relevant session exists, offer a one-session review rather than manufacturing comparison evidence. Create the investigation only when the user wants a durable annotation or review-flow smoke test. Label the checkpoint as single-session evidence and stop before behavior synthesis, cohort creation, or evaluator selection unless later reviewed sessions support those steps.
 
 ### Cold-start
 
@@ -189,20 +193,24 @@ After creation, return a checkpoint card:
 |---|---|
 | Agent | Exact ID and version when known |
 | Investigation | Exact ID |
-| Mode | Trace-first or cold-start |
+| Mode | One-session review, trace-first, or cold-start |
 | Sessions | Count |
 | Questions | Stable keys |
 | Next action | Frontend review or in-chat fallback |
 
 ## Hand off to review
 
-Prefer one continuous Kitaru frontend review block when the product exposes an investigation review link or an agreed URL constructor. Use only the opaque investigation identifier in the URL. Do not encode session lists, questions, or judgments in query parameters.
+Prefer one continuous Kitaru frontend review block. Resolve the review URL in this order:
 
-Present the handoff explicitly:
+1. Use a direct investigation review link returned by Kitaru when one exists.
+2. Otherwise, construct the documented review URL from the configured `dashboard_url`, exact agent ID, and exact investigation ID. For managed Cloud dashboards at `ORIGIN/workspaces/WORKSPACE_ID`, use `ORIGIN/kitaru-workspaces/WORKSPACE_ID/agents/AGENT_ID/investigations/INVESTIGATION_ID/review`. For a dashboard that serves the Kitaru UI directly, use `DASHBOARD_URL/agents/AGENT_ID/investigations/INVESTIGATION_ID/review`.
+3. If the dashboard URL is absent, does not match either documented form, or the constructed route is unavailable, use the in-chat fallback.
+
+Present the resolved URL as a clickable link. If the environment has an ordinary open-URL action and the user wants the page opened, use that action; otherwise leave the link for the user to open in their preferred browser. Do not use Computer Use, browser automation, tab control, or a browser-specific integration for this handoff. Do not encode session lists, questions, annotations, or judgments in the URL.
+
+Begin the handoff with a real Markdown link whose target is the resolved URL, not a label inside a code block. Then say:
 
 ```text
-[Go to the Kitaru frontend now]
-
 Review investigation <id>. Add a written observation for each reviewed session,
 attach observations to exact nodes when relevant, and set a verdict when you have
 one. Leave it unset when you do not want to make a whole-session judgment;
@@ -214,7 +222,7 @@ Pause for the human review. After the user returns, re-read the investigation, e
 
 ### In-chat fallback
 
-When the frontend is not yet available, conduct the same review against the same durable investigation through MCP or structured CLI:
+When no returned or documented review URL reaches the investigation, conduct the same review against the same durable investigation through MCP or structured CLI:
 
 1. Read one complete session and its nodes, including required payloads.
 2. Present the final output, a compact neutral execution outline, the relevant tool or model evidence, and the selection reason.
@@ -313,7 +321,7 @@ Investigation may stop successfully at this checkpoint. If the user wants to tes
 
 ## Preserve failure honesty
 
-- If the frontend is missing, use the in-chat fallback; do not invent a dashboard route.
+- If the investigation cannot be reached through a returned or documented review URL, use the in-chat fallback; do not invent another dashboard route.
 - If agent source cannot be resolved safely, stop before presenting a code-grounded context brief.
 - If full trace payloads are unavailable, identify the missing evidence and do not silently summarize truncated input.
 - If the worker is unavailable, create no fiction about completed analyses or evaluations.

--- a/skills/kitaru-investigation/references/kitaru-operations.md
+++ b/skills/kitaru-investigation/references/kitaru-operations.md
@@ -21,14 +21,17 @@ For agent-facing CLI calls, request structured output and disable incidental int
 --output json --machine --non-interactive --no-browser
 ```
 
-The deliberate frontend handoff is the one browser exception. Do not open a browser for ordinary CLI calls.
+The deliberate frontend handoff may present or open one resolved URL. Do not open a browser for ordinary CLI calls.
 
 Before relying on exact syntax:
 
-1. inspect the installed `kitaru schema` output or command help;
-2. inspect the discovered MCP input schema;
-3. prefer exact IDs and versions over names;
-4. preserve JSON results and carry returned IDs into the next call.
+1. use the Kitaru CLI or MCP connection already configured in the user's environment;
+2. inspect the installed `kitaru schema` output or command help;
+3. inspect the discovered MCP input schema;
+4. prefer exact IDs and versions over names;
+5. preserve JSON results and carry returned IDs into the next call.
+
+If `kitaru` is not available in the current shell, inspect the project's current setup instructions or ask how the user's Kitaru environment is activated. Do not infer a `uv`, `pip`, virtual-environment, or package-install command from the repository layout.
 
 Do not use direct REST calls to fill a missing CLI or MCP contract.
 
@@ -66,6 +69,7 @@ Do not use direct REST calls to fill a missing CLI or MCP contract.
 ### Pre-investigation setup
 
 - Use `kitaru status` first when server selection, credentials, compatibility, or live-worker readiness is uncertain. Use `kitaru doctor` when one of those checks fails or the cause is unclear.
+- Prefer an exact agent version when recording or importing a session. If a session has no `agent_version_id`, report that provenance gap and reconcile it from other evidence only when the program revision is still unambiguous.
 - Inspect the repository before running an agent to record a session. Explain the inputs, credentials, tool effects, and external mutations that may occur, and obtain any approval required by those effects.
 - Use the CLI for a local import payload because MCP never reads local files. Use MCP import only when the payload already exists as a Kitaru blob.
 - Import creates a job and does not make sessions available synchronously unless the CLI waits successfully. Inspect the job and resulting sessions before starting an investigation.
@@ -104,9 +108,21 @@ Do not use direct REST calls to fill a missing CLI or MCP contract.
 
 ## Frontend bridge and fallback
 
-When creation or product configuration exposes an investigation review link, open that link once and pause for the user. The URL must contain only an opaque investigation ID.
+Resolve the frontend URL in this order:
 
-When no link or agreed URL constructor exists:
+1. Use an investigation review link returned by Kitaru when one exists.
+2. Otherwise, read `dashboard_url` from `kitaru status` or equivalent product configuration and construct one of the documented routes below from the exact agent and investigation IDs.
+
+| Dashboard kind | Recognized dashboard URL | Investigation review URL |
+|---|---|---|
+| Managed Cloud | `ORIGIN/workspaces/WORKSPACE_ID` | `ORIGIN/kitaru-workspaces/WORKSPACE_ID/agents/AGENT_ID/investigations/INVESTIGATION_ID/review` |
+| Direct Kitaru UI | A product-configured base URL confirmed to serve the Kitaru UI directly | `DASHBOARD_URL/agents/AGENT_ID/investigations/INVESTIGATION_ID/review` |
+
+Parse the URL and replace only the managed Cloud path shape; do not perform a global text replacement. Use the direct route only when product configuration or server information confirms that the dashboard URL serves Kitaru UI at its base, such as a self-hosted server reporting a non-null `ui_version`. Do not treat every dashboard URL that fails the managed Cloud match as a direct Kitaru UI. Strip a trailing slash before appending the direct route. The route carries agent and investigation identifiers only. Do not add sessions, questions, annotations, judgments, or trace contents as path or query data.
+
+Present the resolved URL as a clickable link. If the environment provides an ordinary open-URL action and the user wants it opened, use that action and then pause. Otherwise, leave the link for the user to open in their preferred browser. Do not use Computer Use, browser automation, tab control, or a browser-specific integration to navigate or annotate on the user's behalf.
+
+When no returned or documented URL reaches the investigation:
 
 1. retain the same investigation and question keys;
 2. read each session through activity operations;
@@ -121,6 +137,7 @@ This is an interaction fallback, not a different persistence model.
 
 ## Known product boundaries
 
+- Current CLI and native MCP investigation creation return the investigation resource without a direct review URL. They expose the agent and investigation IDs needed to construct the documented frontend route from the `dashboard_url` returned by `kitaru status`.
 - No public write path exists for the structured agent-context brief or accepted-behavior record.
 - No operation appends sessions to an active investigation.
 - No persisted skipped-session state exists.


### PR DESCRIPTION
## Summary

Kitaru investigation users can now reach frontend review from CLI- or MCP-created investigations without browser automation. The skill constructs the documented managed Cloud or direct Kitaru UI route from `dashboard_url`, the agent ID, and the investigation ID, presents it as a clickable link, and pauses for the human to annotate.

The flow also supports a one-session review smoke test without implying recurrence or prevalence. Setup guidance now uses the user's configured Kitaru environment and reports missing agent-version provenance instead of guessing package installation or environment commands.

## Reviewer Notes

The main review point is URL recognition. Managed Cloud URLs transform only the exact `/workspaces/WORKSPACE_ID` path shape. Direct Kitaru UI URLs are used only when product configuration or server information confirms that the dashboard serves Kitaru UI at its base. An unmatched dashboard URL falls back to in-chat review rather than receiving a guessed suffix.

### Reproduction

1. Run `kitaru status` against a managed Kitaru workspace and retain its `dashboard_url`.
2. Create or read an investigation and retain its exact `agent_id` and investigation `id`.
3. Construct `ORIGIN/kitaru-workspaces/WORKSPACE_ID/agents/AGENT_ID/investigations/INVESTIGATION_ID/review`.
4. Confirm that the skill presents this as a Markdown link and pauses for the human. It must not invoke Computer Use or browser automation.
5. Repeat with only one eligible session and confirm that the skill stops at a single-session evidence checkpoint before behavior synthesis, cohort creation, or evaluator selection.

Validation: the skill validator passed; plugin metadata parses; `git diff --check` passed; a live staging URL returned HTTP 200 with the expected matched frontend route; and a browserless subagent dry run found no remaining handoff blocker.
